### PR TITLE
reduce the restrictiveness of the filename filter

### DIFF
--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -8,7 +8,25 @@ module AssetCloud
 
   class Base
     cattr_accessor :logger
-    VALID_PATHS = /\A(([a-z0-9])|((\.?[\w\-\@])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@]|[\/][\.][\w\-\@]|[\.][\w\-\@]+)*))\z/i
+    VALID_PATHS = /\A
+      (
+        ([a-z0-9])            #Filename can be a single letter
+        |                     #OR it is many and follows the below rules
+        (
+          (\.?[\w\-\@])       #It can start with a dot but it must have a following character
+          (
+            [\w\-\@]          #You can have a letter without any following conditions
+            |
+            [\ ][\w\-\@]      #If there is a space you need to have a normal letter afterward
+            |
+            [\/][\w\-\@]      #If there is a slash you need to have a normal letter afterward
+            |
+            [\/][\.][\w\-\@]  #Though a slash could be followed by a dot so long as there is a normal letter afterward
+            |
+            [\.][\w\-\@]+     #A dot must be followed by one (or more) normal letters
+          )*                  #Zero to many of these combinations.
+        )
+      )\z/ix                   #Case insensitive
     MATCH_BUCKET = /^(\w+)(\/|$)/
 
     attr_accessor :url, :root

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -10,7 +10,7 @@ module AssetCloud
     cattr_accessor :logger
     VALID_PATHS = /\A
       (
-        ([a-z0-9])            #Filename can be a single letter
+        ([\w])                #Filename can be a single letter or underscore
         |                     #OR it is many and follows the below rules
         (
           (\.?[\w\-\@])       #It can start with a dot but it must have a following character
@@ -26,7 +26,7 @@ module AssetCloud
             [\.][\w\-\@]+     #A dot must be followed by one (or more) normal letters
           )*                  #Zero to many of these combinations.
         )
-      )\z/ix                   #Case insensitive
+      )\z/x                   #Case insensitive
     MATCH_BUCKET = /^(\w+)(\/|$)/
 
     attr_accessor :url, :root

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -9,7 +9,7 @@ module AssetCloud
   class Base
     cattr_accessor :logger
 
-    VALID_PATHS = /\A[a-z0-9][a-z0-9_\-\/]+([a-z0-9][\w\-\ \.\@]*\.\w{2,6})?\z/i
+    VALID_PATHS = /\A([.]?[a-z0-9]|[a-z0=9])[a-z0-9_\-\/]+([a-z0-9_\.][\w\-\ \.\@]*(\.\w{1,6})*)?\z/i
     MATCH_BUCKET = /^(\w+)(\/|$)/
 
     attr_accessor :url, :root

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -8,7 +8,7 @@ module AssetCloud
 
   class Base
     cattr_accessor :logger
-    VALID_PATHS = /\A(([a-z0-9])|((\.?[\w\-\@])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@\.]|[\.][\w\-\@]+)*))\z/i
+    VALID_PATHS = /\A(([a-z0-9])|((\.?[\w\-\@])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@]|[\/][\.][\w\-\@]|[\.][\w\-\@]+)*))\z/i
     MATCH_BUCKET = /^(\w+)(\/|$)/
 
     attr_accessor :url, :root

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -8,7 +8,6 @@ module AssetCloud
 
   class Base
     cattr_accessor :logger
-    #\A(([a-z0-9])|((\.[a-z0-9]|[\w\-\@])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@\.]|[\.][\w\-\@]+)*[\w\-]?))\z
     VALID_PATHS = /\A(([a-z0-9])|((\.?[\w\-\@])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@\.]|[\.][\w\-\@]+)*))\z/i
     MATCH_BUCKET = /^(\w+)(\/|$)/
 

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -8,8 +8,8 @@ module AssetCloud
 
   class Base
     cattr_accessor :logger
-
-    VALID_PATHS = /\A(([a-z0-9])|([a-z0-9]|(\.[a-z0-9]|[\w])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@\.]|[\.][\w\-\@]+)*[\w\-]?))\z/i
+    #\A(([a-z0-9])|((\.[a-z0-9]|[\w\-\@])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@\.]|[\.][\w\-\@]+)*[\w\-]?))\z
+    VALID_PATHS = /\A(([a-z0-9])|((\.?[\w\-\@])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@\.]|[\.][\w\-\@]+)*))\z/i
     MATCH_BUCKET = /^(\w+)(\/|$)/
 
     attr_accessor :url, :root

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -9,7 +9,7 @@ module AssetCloud
   class Base
     cattr_accessor :logger
 
-    VALID_PATHS = /\A(([a-z0-9])|([a-z0-9]|(\.?[a-z0-9]|[\w])([\w\-\@]|[\w\-\@\ ][\w\-\@]|[\w\-\@\/][\w\-\@\.]|[\w\-\@\.][\w\-\@\/])*[\w\-]))\z/i
+    VALID_PATHS = /\A(([a-z0-9])|([a-z0-9]|(\.[a-z0-9]|[\w])([\w\-\@]|[\ ][\w\-\@]|[\/][\w\-\@\.]|[\.][\w\-\@]+)*[\w\-]?))\z/i
     MATCH_BUCKET = /^(\w+)(\/|$)/
 
     attr_accessor :url, :root

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -9,7 +9,7 @@ module AssetCloud
   class Base
     cattr_accessor :logger
 
-    VALID_PATHS = /\A([.]?[a-z0-9]|[a-z0=9])[a-z0-9_\-\/]+([a-z0-9_\.][\w\-\ \.\@]*(\.\w{1,6})*)?\z/i
+    VALID_PATHS = /\A(([a-z0-9])|([a-z0-9]|(\.?[a-z0-9]|[\w])([\w\-\@]|[\w\-\@\ ][\w\-\@]|[\w\-\@\/][\w\-\@\.]|[\w\-\@\.][\w\-\@\/])*[\w\-]))\z/i
     MATCH_BUCKET = /^(\w+)(\/|$)/
 
     attr_accessor :url, :root

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -43,7 +43,17 @@ describe BasicCloud do
   end
 
   it "should raise error when using with minus relative even after another directory" do
+    lambda { @fs['test/../test']   }.should raise_error(AssetCloud::IllegalPath)
     lambda { @fs['test/../../test']   }.should raise_error(AssetCloud::IllegalPath)
+    lambda { @fs['test/../../../test']   }.should raise_error(AssetCloud::IllegalPath)
+  end
+
+  it "should raise an error when using names with bizarre combinations of '.' and ' '" do
+    lambda { @fs['test. . . .. ... .. . ']   }.should raise_error(AssetCloud::IllegalPath)
+  end
+
+  it "should not raise an error when using directory names with spaces" do
+    @fs['files/ass ets/.DS_Store']
   end
 
   it "should not raise_error when using unusual but valid filenames" do
@@ -51,10 +61,12 @@ describe BasicCloud do
     @fs['photograph.g']
     @fs['assets/.DS_Store']
     @fs['assets/photograph.g']
+    @fs['a']
   end
 
   it "should allow sensible relative filenames" do
     @fs['assets/rails_logo.gif']
+    @fs['assets/rails_logo']
     @fs['assets/rails-2.gif']
     @fs['assets/223434.gif']
     @fs['files/1.JPG']

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -42,10 +42,16 @@ describe BasicCloud do
     lambda { @fs['./test']   }.should raise_error(AssetCloud::IllegalPath)
   end
 
+  it "should raise error when filename has trailing period" do
+    lambda { @fs['test.']           }.should raise_error(AssetCloud::IllegalPath)
+    lambda { @fs['/test/testfile.'] }.should raise_error(AssetCloud::IllegalPath)
+    lambda { @fs['test/directory/.']}.should raise_error(AssetCloud::IllegalPath)
+  end
+
   it "should raise error when using with minus relative even after another directory" do
-    lambda { @fs['test/../test']   }.should raise_error(AssetCloud::IllegalPath)
+    lambda { @fs['test/../test']      }.should raise_error(AssetCloud::IllegalPath)
     lambda { @fs['test/../../test']   }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/../../../test']   }.should raise_error(AssetCloud::IllegalPath)
+    lambda { @fs['test/../../../test']}.should raise_error(AssetCloud::IllegalPath)
   end
 
   it "should raise an error when using names with bizarre combinations of '.' and ' '" do

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -42,6 +42,17 @@ describe BasicCloud do
     lambda { @fs['./test']   }.should raise_error(AssetCloud::IllegalPath)
   end
 
+  it "should raise error when using with minus relative even after another directory" do
+    lambda { @fs['test/../../test']   }.should raise_error(AssetCloud::IllegalPath)
+  end
+
+  it "should not raise_error when using unusual but valid filenames" do
+    @fs['.DS_Store']
+    @fs['photograph.g']
+    @fs['assets/.DS_Store']
+    @fs['assets/photograph.g']
+  end
+
   it "should allow sensible relative filenames" do
     @fs['assets/rails_logo.gif']
     @fs['assets/rails-2.gif']

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -65,8 +65,10 @@ describe BasicCloud do
   it "should not raise_error when using unusual but valid filenames" do
     @fs['.DS_Store']
     @fs['photograph.g']
+    @fs['_testfilename']
     @fs['assets/.DS_Store']
     @fs['assets/photograph.g']
+    @fs['a/_testfilename']
     @fs['a']
   end
 


### PR DESCRIPTION
This new regex should allow single character extensions as well as files that start with a '.'. Both of which are valid.

I added a test for relative directories with a directory lead-in and for the two new cases we were trying to remedy.

Addresses issue #9 

@disaacs @bouk @berkcaputcu 