### PR TITLE
raise `AssetNotSaved` with proper message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.bundle
 .DS_Store
 Gemfile.lock
 *.orig

--- a/lib/asset_cloud/asset.rb
+++ b/lib/asset_cloud/asset.rb
@@ -118,7 +118,7 @@ module AssetCloud
     end
 
     def store!
-      store or raise AssetNotSaved
+      store or raise(AssetNotSaved, "Validation failed: #{errors.join(', ')}")
     end
 
     def to_param

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -39,6 +39,16 @@ describe ValidatedAsset do
     end
   end
 
+  describe "#store!" do
+    it "should raise AssetNotFound with error message when validation fails" do
+      expect { @cat.store! }.to raise_error(AssetCloud::AssetNotSaved, "Validation failed: no cats allowed!")
+    end
+
+    it "should return true when validations pass" do
+      @dog.store!.should == true
+    end
+  end
+
   describe "#valid?" do
     it "should clear errors, run validations, and return validity" do
       @cat.store


### PR DESCRIPTION
This fixes the annoying `AssetCloud::AssetNotSaved:         AssetCloud::AssetNotSaved: AssetCloud::AssetNotSaved` that gets thrown when you do `store!` on an asset that's invalid. This is especially irksome when trying to go red-green TDD coz the error gives no idea why the saving failed.

@Thibaut @karlhungus 