### PR TITLE
Allow asset_class to be a proc which determines the class to use within a bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - '1.9.3'
   - '2.0'

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Asset Cloud Version History
 
+## Version 2.2.2, 2016-02-11
+
+* Allow asset_class to be a proc which determines the class to use within a bucket (https://github.com/Shopify/asset_cloud/pull/15)
+
 ## Version 2.2.0, 2015-03-17
 
 * Reduce the limitations on filenames so as not to catch valid filenames. (https://github.com/Shopify/asset_cloud/pull/12)

--- a/asset_cloud.gemspec
+++ b/asset_cloud.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{asset_cloud}
-  s.version = "2.2.1"
+  s.version = "2.2.2"
 
   s.authors = %w(Shopify)
   s.summary = %q{An abstraction layer around arbitrary and diverse asset stores.}

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -60,7 +60,10 @@ module AssetCloud
         self.asset_classes[bucket_name.to_sym]  = asset_class if asset_class
       else
         self.root_bucket_class = bucket_class
-        self.root_asset_class  = asset_class if asset_class
+        if asset_class
+          raise ArgumentError, 'asset_class on the root bucket cannot be a proc' if asset_class.is_a?(Proc)
+          self.root_asset_class  = asset_class
+        end
       end
     end
 
@@ -216,7 +219,10 @@ module AssetCloud
     end
 
     def asset_class_for(key)
-      klass = self.class.asset_classes[bucket_symbol_for_key(key)] || self.class.root_asset_class
+      klass = self.class.asset_classes[bucket_symbol_for_key(key)]
+      klass = klass.call(key) if klass.is_a?(Proc)
+      klass ||= self.class.root_asset_class
+
       constantize_if_necessary(klass)
     end
 


### PR DESCRIPTION
This allows `asset_class` argument on `bucket` to be a proc which takes in the asset's key and returns the class to use. `asset_class` can still be a specific class as well.

Example:
```ruby
  bucket :special, AssetCloud::MemoryBucket, asset_class: SpecialAsset
  bucket :conditional, AssetCloud::MemoryBucket, asset_class: -> (key) {
    key.ends_with?('.liquid') ? LiquidAsset : AssetCloud::Asset
  }
```

@gauravmc @Thibaut 