### PR TITLE
Tweak asset path validation for easier extensability

### DIFF
--- a/asset_cloud.gemspec
+++ b/asset_cloud.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{asset_cloud}
-  s.version = "2.2.2"
+  s.version = "2.2.3"
 
   s.authors = %w(Shopify)
   s.summary = %q{An abstraction layer around arbitrary and diverse asset stores.}

--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -42,12 +42,18 @@ AssetCloud::Asset.class_eval do
     @extensions.each {|ext| ext.execute_callbacks(symbol, args)}
   end
 
+  protected
+
+  def valid_key_path?(key)
+    key !~ AssetCloud::Base::VALID_PATHS
+  end
+
   private
 
   def valid_key
     if key.blank?
       add_error "key cannot be empty"
-    elsif key !~ AssetCloud::Base::VALID_PATHS
+    elsif valid_key_path?(key)
       add_error "#{key.inspect} contains illegal characters"
     end
   end


### PR DESCRIPTION
I want to add path validation on file names on our sections and blocks without having similar error messages as those asset cloud already adds. Rather than create a new validation this will let us do the following in our subclass:
```ruby
def valid_key_path?(key)
  super && key !~ SOME_OTHER_REGEX
end
```

and then only have the one error message

@gauravmc
CC @Thibaut 