### PR TITLE
Reverse the valid_key_path? logic

### DIFF
--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -45,7 +45,7 @@ AssetCloud::Asset.class_eval do
   protected
 
   def valid_key_path?(key)
-    key !~ AssetCloud::Base::VALID_PATHS
+    key =~ AssetCloud::Base::VALID_PATHS
   end
 
   private
@@ -53,7 +53,7 @@ AssetCloud::Asset.class_eval do
   def valid_key
     if key.blank?
       add_error "key cannot be empty"
-    elsif valid_key_path?(key)
+    elsif !valid_key_path?(key)
       add_error "#{key.inspect} contains illegal characters"
     end
   end


### PR DESCRIPTION
#16 worked but I accidentally had the logic reversed in the two places such that they compensated, but the logic didn't actually read right. It would have been accurate to call the method `invalid_key_path?`

@gauravmc 