### PR TITLE
allow read to take an argument hash

### DIFF
--- a/lib/asset_cloud/buckets/s3_bucket.rb
+++ b/lib/asset_cloud/buckets/s3_bucket.rb
@@ -11,8 +11,8 @@ module AssetCloud
       objects.map { |o| cloud[relative_key(o.key)] }
     end
 
-    def read(key)
-      cloud.s3_bucket(key).objects[absolute_key(key)].read
+    def read(key, options = {})
+      cloud.s3_bucket(key).objects[absolute_key(key)].read(options)
     rescue ::AWS::Errors::Base
       raise AssetCloud::AssetNotFoundError, key
     end

--- a/spec/remote_s3_bucket_spec.rb
+++ b/spec/remote_s3_bucket_spec.rb
@@ -66,4 +66,13 @@ describe 'Remote test for AssetCloud::S3Bucket', if:  ENV['AWS_ACCESS_KEY_ID'] &
     data = @bucket.read(key)
     data.should == value
   end
+
+  it "#reads first bytes when passed options" do
+    value = 'hello world'
+    key = 'tmp/new_file.txt'
+    options = {range: 0...5}
+    @bucket.write(key, value)
+    data = @bucket.read(key, options)
+    data.should == 'hello'
+  end
 end


### PR DESCRIPTION
The read and write operations take options that are passed along to the AWS library. The write operation includes the options hash but the read operation does not. This PR remedies that without changing anything by passing an options hash to the read operation that is by default empty.

This will allow use of, for instance, version-specific reading, client or server side encryption, or reading for only a particular byte range (which could allow for just reading headers).

More information here: http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3/S3Object.html#read-instance_method

@DrewMartin @gauravmc @karlhungus 