### PR TITLE
Get rid of alias_method_chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,5 @@ language: ruby
 before_install:
   - gem install bundler
 rvm:
-  - '1.9.3'
-  - '2.0'
-  - '2.1'
-  - 2.1.2
+  - '2.2'
+  - '2.3'

--- a/asset_cloud.gemspec
+++ b/asset_cloud.gemspec
@@ -8,6 +8,8 @@ Gem::Specification.new do |s|
   s.summary = %q{An abstraction layer around arbitrary and diverse asset stores.}
   s.description = %q{An abstraction layer around arbitrary and diverse asset stores.}
 
+  s.required_ruby_version = '>= 2.2.0'
+
   s.email = %q{developers@shopify.com}
   s.homepage = %q{http://github.com/Shopify/asset_cloud}
   s.require_paths = %w(lib)
@@ -21,8 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'
-  if RUBY_VERSION >= "2.0.0"
-    s.add_development_dependency 'pry'
-    s.add_development_dependency 'pry-byebug'
-  end
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-byebug'
 end

--- a/lib/asset_cloud/validations.rb
+++ b/lib/asset_cloud/validations.rb
@@ -2,10 +2,13 @@ module AssetCloud
   module Validations
     def self.included(base)
       base.extend ClassMethods
-      base.class_eval do
-        include AssetCloud::Callbacks
+      base.prepend PrependedMethods
+    end
 
-        alias_method_chain :store, :validation
+    module PrependedMethods
+      def store
+        validate
+        errors.empty? ? super : false
       end
     end
 
@@ -14,11 +17,6 @@ module AssetCloud
         validations << block if block_given?
         write_inheritable_array(:validate, validations)
       end
-    end
-
-    def store_with_validation
-      validate
-      errors.empty? ? store_without_validation : false
     end
 
     def errors


### PR DESCRIPTION
It's deprecated in Rails 5.0.

However it mean dropping 1.9.3 support, but I think it's time.

Also since the activesupport version isn't locked, it's now trying to install 5.0, which requires ruby 2.2.

@Shopify/rails5 for review please.