### PR TITLE
Upgrade to aws-sdk 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'aws-sdk', '~> 1.34.0', :require => nil
+gem 'aws-sdk', '~> 2.7', :require => nil
 
 gemspec

--- a/lib/asset_cloud/buckets/s3_bucket.rb
+++ b/lib/asset_cloud/buckets/s3_bucket.rb
@@ -17,7 +17,9 @@ module AssetCloud
 
       object = cloud.s3_bucket(key)
         .object(absolute_key(key))
-        .get(options).body.read
+        .get(options)
+
+      object.body.respond_to?(:read) ? object.body.read : object.body
     rescue ::Aws::Errors::ServiceError
       raise AssetCloud::AssetNotFoundError, key
     end

--- a/lib/asset_cloud/buckets/s3_bucket.rb
+++ b/lib/asset_cloud/buckets/s3_bucket.rb
@@ -36,8 +36,8 @@ module AssetCloud
     end
 
     def stat(key)
-      bucket_name = cloud.s3_bucket(key).name
-      metadata = s3_client.head_object(bucket: bucket_name, key: absolute_key(key))
+      bucket = cloud.s3_bucket(key)
+      metadata = bucket.client.head_object(bucket: bucket.name, key: absolute_key(key))
 
       AssetCloud::Metadata.new(true, metadata[:content_length], nil, metadata[:last_modified])
     rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::NotFound
@@ -68,10 +68,6 @@ module AssetCloud
       # follows https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
       return "bytes=#{[range.begin, range.max].join('-')}" if range.is_a?(Range)
       range
-    end
-
-    def s3_client
-      cloud.s3_connection.client
     end
   end
 end

--- a/lib/asset_cloud/buckets/s3_bucket.rb
+++ b/lib/asset_cloud/buckets/s3_bucket.rb
@@ -40,7 +40,7 @@ module AssetCloud
       metadata = s3_client.head_object(bucket: bucket_name, key: absolute_key(key))
 
       AssetCloud::Metadata.new(true, metadata[:content_length], nil, metadata[:last_modified])
-    rescue Aws::S3::Errors::NoSuchKey
+    rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::NotFound
       AssetCloud::Metadata.new(false)
     end
 

--- a/lib/asset_cloud/buckets/s3_bucket.rb
+++ b/lib/asset_cloud/buckets/s3_bucket.rb
@@ -1,46 +1,49 @@
-require 'aws'
+require 'aws-sdk'
 
 module AssetCloud
   class S3Bucket < Bucket
     def ls(key = nil)
       key = absolute_key(key)
 
-      objects = cloud.s3_bucket(key).objects
-      objects = objects.with_prefix(key) if key
+      options = {}
+      options[:prefix] = key if key
 
+      objects = cloud.s3_bucket(key).objects(options)
       objects.map { |o| cloud[relative_key(o.key)] }
     end
 
     def read(key, options = {})
-      cloud.s3_bucket(key).objects[absolute_key(key)].read(options)
-    rescue ::AWS::Errors::Base
+      options[:range] = http_byte_range(options[:range]) if options[:range]
+
+      object = cloud.s3_bucket(key)
+        .object(absolute_key(key))
+        .get(options).body.read
+    rescue ::Aws::Errors::ServiceError
       raise AssetCloud::AssetNotFoundError, key
     end
 
     def write(key, data, options = {})
-      object = cloud.s3_bucket(key).objects[absolute_key(key)]
-
-      object.write(data, options)
+      object = cloud.s3_bucket(key).object(absolute_key(key))
+      object.put(options.merge(body: data))
     end
 
     def delete(key)
-      object = cloud.s3_bucket(key).objects[absolute_key(key)]
-
+      object = cloud.s3_bucket(key).object(absolute_key(key))
       object.delete
-
       true
     end
 
     def stat(key)
-      object = cloud.s3_bucket(key).objects[absolute_key(key)]
-      metadata = object.head
+      bucket_name = cloud.s3_bucket(key).name
+      metadata = s3_client.head_object(bucket: bucket_name, key: absolute_key(key))
 
       AssetCloud::Metadata.new(true, metadata[:content_length], nil, metadata[:last_modified])
-    rescue AWS::S3::Errors::NoSuchKey
+    rescue Aws::S3::Errors::NoSuchKey
       AssetCloud::Metadata.new(false)
     end
 
-    protected
+    private
+
     def path_prefix
       @path_prefix ||= @cloud.url
     end
@@ -57,6 +60,16 @@ module AssetCloud
 
     def relative_key(key)
       key =~ /^#{path_prefix}\/(.+)/ ? $1 : key
+    end
+
+    def http_byte_range(range)
+      # follows https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+      return "bytes=#{[range.begin, range.max].join('-')}" if range.is_a?(Range)
+      range
+    end
+
+    def s3_client
+      cloud.s3_connection.client
     end
   end
 end

--- a/spec/mock_s3_interface.rb
+++ b/spec/mock_s3_interface.rb
@@ -31,7 +31,8 @@ class MockS3Interface
     def head_object(options = {})
       options = interface
         .bucket(options[:bucket])
-        .object(options[:key]).get()
+        .object(options[:key])
+        .get
 
       {
         content_length: options.body.size,
@@ -59,7 +60,7 @@ class MockS3Interface
 
     def put_object(options = {})
       options = options.dup
-      options[:body] = StringIO.new(options[:body].force_encoding(Encoding::BINARY))
+      options[:body] = options[:body].force_encoding(Encoding::BINARY)
 
       key = options.delete(:key)
 

--- a/spec/mock_s3_interface.rb
+++ b/spec/mock_s3_interface.rb
@@ -54,8 +54,8 @@ class MockS3Interface
       objects
     end
 
-    def object(name)
-      @storage[name] ||= S3Object.new(self, name)
+    def object(key)
+      @storage[key] ||= NullS3Object.new(self, key)
     end
 
     def put_object(options = {})
@@ -68,17 +68,31 @@ class MockS3Interface
       true
     end
 
-    def delete(key)
-      @storage.delete(key)
-      true
-    end
-
     def clear
       @storage = {}
     end
 
     def inspect
       "#<MockS3Interface::Bucket @name=#{@name.inspect}, @storage.keys = #{@storage.keys.inspect}>"
+    end
+  end
+
+  class NullS3Object
+    attr_reader :key
+    def initialize(bucket, key)
+      @bucket = bucket
+      @key = key
+    end
+
+    def get(*)
+      raise Aws::S3::Errors::NoSuchKey(nil, nil)
+    end
+
+    def delete(*)
+    end
+
+    def put(options = {})
+      @bucket.put_object(options.merge(key: @key))
     end
   end
 
@@ -93,6 +107,7 @@ class MockS3Interface
 
     def delete
       @bucket.delete(@key)
+      true
     end
 
     def get(*)

--- a/spec/remote_s3_bucket_spec.rb
+++ b/spec/remote_s3_bucket_spec.rb
@@ -5,22 +5,26 @@ class RemoteS3Cloud < AssetCloud::Base
   bucket :tmp, AssetCloud::S3Bucket
 
   def s3_bucket(key)
-    s3_connection.buckets[ENV['S3_BUCKET_NAME']]
+    s3_connection.bucket(ENV['S3_BUCKET_NAME'])
   end
 end
 
-describe 'Remote test for AssetCloud::S3Bucket', if:  ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY'] && ENV['S3_BUCKET_NAME'] do
+describe 'Remote test for AssetCloud::S3Bucket', if: ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY'] && ENV['S3_BUCKET_NAME'] do
   require 'aws-sdk'
 
   directory = File.dirname(__FILE__) + '/files'
 
   before(:all) do
-    AWS.config({
-      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
-    })
+    Aws.config = {
+      region: ENV.fetch('AWS_REGION', 'us-east-1'),
+      credentials: Aws::Credentials.new(
+        ENV['AWS_ACCESS_KEY_ID'],
+        ENV['AWS_SECRET_ACCESS_KEY'],
+      ),
+    }
+
     @cloud = RemoteS3Cloud.new(directory , 'testing/assets/files' )
-    @cloud.s3_connection = AWS::S3.new()
+    @cloud.s3_connection = Aws::S3::Resource.new
     @bucket = @cloud.buckets[:tmp]
   end
 
@@ -35,9 +39,18 @@ describe 'Remote test for AssetCloud::S3Bucket', if:  ENV['AWS_ACCESS_KEY_ID'] &
 
     ls = @bucket.ls('tmp')
 
-    ls.first.class.should == AssetCloud::Asset
-    keys = ls.map(&:key)
-    ['tmp/test1.txt', 'tmp/test2.txt'].all? {|key| keys.include? key }
+    expect(ls).to all(be_an(AssetCloud::Asset))
+    expect(ls.map(&:key) - ['tmp/test1.txt', 'tmp/test2.txt']).to be_empty
+  end
+
+  it "#ls returns all assets" do
+    @cloud['tmp/test1.txt'] = 'test1'
+    @cloud['tmp/test2.txt'] = 'test2'
+
+    ls = @bucket.ls
+
+    expect(ls).to all(be_an(AssetCloud::Asset))
+    expect(ls.map(&:key) - ['tmp/test1.txt', 'tmp/test2.txt']).to be_empty
   end
 
   it "#delete should ignore errors when deleting" do

--- a/spec/remote_s3_bucket_spec.rb
+++ b/spec/remote_s3_bucket_spec.rb
@@ -72,12 +72,22 @@ describe 'Remote test for AssetCloud::S3Bucket', if: ENV['AWS_ACCESS_KEY_ID'] &&
     metadata.updated_at.should >= start_time
   end
 
+  it "#stat a missing asset" do
+    metadata = @bucket.stat('i_do_not_exist_and_never_will.test')
+    expect(metadata).to be_an(AssetCloud::Metadata)
+    expect(metadata.exist).to be false
+  end
+
   it "#read " do
     value = 'hello world'
     key = 'tmp/new_file.txt'
     @bucket.write(key, value)
     data = @bucket.read(key)
     data.should == value
+  end
+
+  it "#read a missing asset" do
+    expect { @bucket.read("i_do_not_exist_and_never_will.test") }.to raise_error(AssetCloud::AssetNotFoundError)
   end
 
   it "#reads first bytes when passed options" do

--- a/spec/s3_bucket_spec.rb
+++ b/spec/s3_bucket_spec.rb
@@ -39,13 +39,13 @@ describe AssetCloud::S3Bucket do
   end
 
   it "#delete should not ignore errors when deleting" do
-    expect_any_instance_of(MockS3Interface::Bucket).to receive(:delete).and_raise(StandardError)
+    expect_any_instance_of(MockS3Interface::NullS3Object).to receive(:delete).and_raise(StandardError)
 
     expect { @bucket.delete('assets/fail.gif') }.to raise_error(StandardError)
   end
 
   it "#delete should always return true" do
-    expect_any_instance_of(MockS3Interface::Bucket).to receive(:delete).and_return(nil)
+    expect_any_instance_of(MockS3Interface::NullS3Object).to receive(:delete).and_return(nil)
 
     @bucket.delete('assets/fail.gif').should == true
   end

--- a/spec/s3_bucket_spec.rb
+++ b/spec/s3_bucket_spec.rb
@@ -6,7 +6,7 @@ class S3Cloud < AssetCloud::Base
   attr_accessor :s3_connection, :s3_bucket_name
 
   def s3_bucket(key)
-    s3_connection.buckets[s3_bucket_name]
+    s3_connection.bucket(s3_bucket_name)
   end
 end
 
@@ -27,11 +27,15 @@ describe AssetCloud::S3Bucket do
   end
 
   it "#ls should return assets with proper keys" do
-    collection = MockS3Interface::Collection.new(nil, ["#{@cloud.url}/tmp/blah.gif", "#{@cloud.url}/tmp/add_to_cart.gif"])
+    collection = ["#{@cloud.url}/tmp/blah.gif", "#{@cloud.url}/tmp/add_to_cart.gif"].map do |key|
+      MockS3Interface::S3Object.new(nil, key)
+    end
     expect_any_instance_of(MockS3Interface::Bucket).to receive(:objects).and_return(collection)
+
     ls = @bucket.ls('tmp')
-    ls.first.class.should == AssetCloud::Asset
-    ls.map(&:key).should == ['tmp/blah.gif', 'tmp/add_to_cart.gif']
+
+    expect(ls).to all(be_an(AssetCloud::Asset))
+    expect(ls.map(&:key) - ['tmp/blah.gif', 'tmp/add_to_cart.gif']).to be_empty
   end
 
   it "#delete should not ignore errors when deleting" do


### PR DESCRIPTION
This PR upgrade aws-sdk from 1.34.0 to 2.7. Heres a list of notable changes:

- buckets[bucket_name] -> bucket(bucket_name)
- bucket(bucket_name).objects[object_name] -> bucket(bucket_name).object(object_name)
- object.read(options) -> object.get(options).body.read
- object.head -> moved to client.head_object(bucket: bucket_name, key: object_key)

I've essentially followed the migration guide here: https://github.com/aws/aws-sdk-ruby/blob/master/MIGRATING.md and confirmed it worked with the remote tests.

@karlhungus @Shopify/byroot 