### PR TITLE
Use Addressable instead of broken stdlib URI escaping

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'addressable', '~> 2.6', require: nil
+gem 'addressable', '~> 2.2', require: nil
 gem 'aws-sdk', '~> 1.34.0', require: nil
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'aws-sdk', '~> 1.34.0', :require => nil
+gem 'addressable', '~> 2.6', require: nil
+gem 'aws-sdk', '~> 1.34.0', require: nil
 
 gemspec

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -1,4 +1,6 @@
-require 'uri'
+# frozen_string_literal: true
+
+require 'addressable/uri'
 require 'class_inheritable_attributes'
 
 module AssetCloud
@@ -94,7 +96,7 @@ module AssetCloud
     end
 
     def url_for(key, options={})
-      File.join(@url, URI.encode(key))
+      File.join(@url, Addressable::URI.encode(key))
     end
 
     def path_for(key)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -128,6 +128,10 @@ describe BasicCloud do
     @fs.url_for('products/key with spaces.txt').should == 'http://assets/files/products/key%20with%20spaces.txt'
   end
 
+  it 'escapes square brackets in asset urls' do
+    @fs.url_for('hello[world]').should == 'http://assets/files/hello%5Bworld%5D'
+  end
+
   describe "#find" do
     it "should return the appropriate asset when one exists" do
       asset = @fs.find('products/key.txt')


### PR DESCRIPTION
The native Ruby implementation of URI escaping is broken, and has been deprecated for over 10 years. For example, despite the documentations claims that URI::INVALID characters are removed by default, this is not the case, as square brackets are left in place despite being present in that regex.

We cannot use CGI.escape in this case because CGI.escape uses x-www-form-encoded formatting (where spaces are replaced with +) instead of the correct %20 escaping used in URLs.

* Add Addressable as a dependency
* Use Addressable when generating URLs for asset keys