### PR TITLE
Prevent callback from executing if before_callback returns false

### DIFF
--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -38,7 +38,8 @@ AssetCloud::Asset.class_eval do
   validate :valid_key
 
   def execute_callbacks(symbol, args)
-    super
+    result = super
+    return result if result == false
     @extensions.each {|ext| ext.execute_callbacks(symbol, args)}
   end
 


### PR DESCRIPTION
I want to prevent the deletion of an asset in the case that it is referenced elsewhere. To do this, I want to use the `before_delete` callback. However, I noticed that even when the function that is specified returns `false`, the `false` result gets suppressed and the callback executes anyways. 

I am not too familiar with AssetCloud so I'm not sure whether this could cause any issues that I'm unaware of, please let me know if this is the case!