### PR TITLE
Get rid of the missed inheritable_attribute usages

### DIFF
--- a/lib/asset_cloud/validations.rb
+++ b/lib/asset_cloud/validations.rb
@@ -14,9 +14,12 @@ module AssetCloud
     end
 
     module ClassMethods
-      def validate(*validations, &block)
+      def validate(*extra_validations, &block)
+        validations = self._callbacks[:validate] || []
+        validations += extra_validations
         validations << block if block_given?
-        write_inheritable_array(:validate, validations)
+
+        self._callbacks = _callbacks.merge(validate: validations.freeze).freeze
       end
     end
 


### PR DESCRIPTION
Followup: https://github.com/Shopify/asset_cloud/pull/40

I missed some `write_inheritable_array` uses in callbacks & validations.

The whole thing is a bit messy, bit I managed to reproduce the behavior with relatively simple code.

Note that the validation logic piggy back on the callback one but bypass it's API entirely...

I know there is probably a billion refactors that could be done, but I'd like to stick to just getting rid of `class_inheritable_attributes` and no end up in a giant rabbit hole.