### PR TITLE
Add GCS bucket

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'aws-sdk', '~> 1.34.0', :require => nil
+gem 'google-cloud-storage'
 
 gemspec

--- a/README.rdoc
+++ b/README.rdoc
@@ -18,6 +18,10 @@ With S3 Remote test:
 
     AWS_ACCESS_KEY_ID="<s3_key>" AWS_SECRET_ACCESS_KEY="<s3_secret_key>" S3_BUCKET_NAME="<bucket_name>" bundle exec rake spec
 
+With GCS Remote test:
+
+    GCS_PROJECT_ID="<project_id>" GCS_KEY_FILEPATH="<path_to_key>" GCS_BUCKET="<bucket_name>" bundle exec rake spec
+
 == Copyright
 
 Copyright (c) 2008-2014 Tobias Lütke & Shopify, Inc. Released under the MIT license (see LICENSE for details).

--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -16,6 +16,9 @@ require 'asset_cloud/base'
 # S3
 require 'asset_cloud/buckets/s3_bucket'
 
+# GCS
+require 'asset_cloud/buckets/gcs_bucket'
+
 # Extensions
 require 'asset_cloud/free_key_locator'
 require 'asset_cloud/callbacks'

--- a/lib/asset_cloud/buckets/gcs_bucket.rb
+++ b/lib/asset_cloud/buckets/gcs_bucket.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module AssetCloud
+  class GCSBucket < Bucket
+    def ls(key = nil)
+      key ? find_by_key!(key) : bucket.files
+    end
+
+    def read(key)
+      file = find_by_key!(key)
+      downloaded = file.download
+      downloaded.rewind
+      downloaded.read
+    end
+
+    def write(key, data)
+      bucket.create_file(data, full_path(key))
+    end
+
+    def delete(key)
+      file = find_by_key!(key)
+      file.delete
+    end
+
+    def clear
+      bucket.files.each(&:delete)
+    end
+
+    def stat(key)
+      begin
+        file = find_by_key!(key)
+        Metadata.new(true, file.size, file.created_at, file.updated_at)
+      rescue AssetCloud::AssetNotFoundError
+        Metadata.new(false)
+      end
+    end
+
+    private
+
+    def bucket
+      @bucket ||= cloud.gcs_bucket
+    end
+
+    def full_path(key)
+      "s#{cloud.url}/#{key}"
+    end
+
+    def find_by_key!(key)
+      file = bucket.file(full_path(key))
+
+      raise AssetCloud::AssetNotFoundError, key unless file
+
+      file
+    end
+  end
+end

--- a/lib/asset_cloud/buckets/gcs_bucket.rb
+++ b/lib/asset_cloud/buckets/gcs_bucket.rb
@@ -14,7 +14,7 @@ module AssetCloud
     end
 
     def write(key, data)
-      bucket.create_file(data, full_path(key))
+      bucket.create_file(data, absolute_key(key))
     end
 
     def delete(key)
@@ -41,12 +41,22 @@ module AssetCloud
       @bucket ||= cloud.gcs_bucket
     end
 
-    def full_path(key)
-      "s#{cloud.url}/#{key}"
+    def absolute_key(key = nil)
+      if key.to_s.starts_with?(path_prefix)
+        return key
+      else
+        args = [path_prefix]
+        args << key.to_s if key
+        args.join('/')
+      end
+    end
+
+    def path_prefix
+      @path_prefix ||= "s#{@cloud.url}"
     end
 
     def find_by_key!(key)
-      file = bucket.file(full_path(key))
+      file = bucket.file(absolute_key(key))
 
       raise AssetCloud::AssetNotFoundError, key unless file
 

--- a/spec/gcs_bucket_remote_spec.rb
+++ b/spec/gcs_bucket_remote_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+# rubocop:disable RSpec/FilePath, Lint/MissingCopEnableDirective
+
+require 'spec_helper'
+require 'google/cloud/storage'
+
+class RemoteGCSCloud < AssetCloud::Base
+  attr_accessor :gcs_connection
+  bucket :tmp, AssetCloud::GCSBucket
+
+  def gcs_bucket
+    gcs_connection.bucket(ENV['GCS_BUCKET'])
+  end
+end
+
+describe AssetCloud::GCSBucket, if: ENV['GCS_PROJECT_ID'] && ENV['GCS_KEY_FILEPATH'] && ENV['GCS_BUCKET'] do
+  directory = File.dirname(__FILE__) + '/files'
+
+  before(:all) do
+    @cloud = RemoteGCSCloud.new(directory, 'assets/files')
+
+    @cloud.gcs_connection = Google::Cloud::Storage.new(
+        project_id: ENV['GCS_PROJECT_ID'],
+        credentials: ENV['GCS_KEY_FILEPATH']
+      )
+    @bucket = @cloud.buckets[:tmp]
+  end
+
+  after(:all) do
+    @bucket.clear
+  end
+
+  it "#ls with no arguments returns all files in the bucket" do
+    expect_any_instance_of(Google::Cloud::Storage::Bucket).to receive(:files).with(no_args)
+    expect do
+      @bucket.ls
+    end.not_to raise_error
+  end
+
+  it "#ls with arguments returns the file" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/ls.txt'
+
+    @bucket.write(key, local_path)
+
+    file = @bucket.ls(key)
+    expect(file.name).to eq("s#{@cloud.url}/#{key}")
+  end
+
+  it "#write writes a file into the bucket" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/key.txt'
+
+    @bucket.write(key, local_path)
+  end
+
+  it "#delete removes the file from the bucket" do
+    key = 'test/key.txt'
+
+    expect do
+      @bucket.delete(key)
+    end.not_to raise_error
+  end
+
+  it "#delete raises AssetCloud::AssetNotFoundError if the file is not found" do
+    key = 'tmp/not_found.txt'
+    expect do
+      @bucket.delete(key)
+    end.to raise_error(AssetCloud::AssetNotFoundError)
+  end
+
+  it "#read returns the data of the file" do
+    value = 'hello world'
+    key = 'tmp/new_file.txt'
+    @bucket.write(key, StringIO.new(value))
+
+    data = @bucket.read(key)
+    data.should == value
+  end
+
+  it "#read raises AssetCloud::AssetNotFoundError if the file is not found" do
+    key = 'tmp/not_found.txt'
+    expect do
+      @bucket.read(key)
+    end.to raise_error(AssetCloud::AssetNotFoundError)
+  end
+
+  it "#stats returns metadata of the asset" do
+    value = 'hello world'
+    key = 'tmp/new_file.txt'
+    @bucket.write(key, StringIO.new(value))
+
+    stats = @bucket.stat(key)
+
+    expect(stats.size).not_to be_nil
+    expect(stats.created_at).not_to be_nil
+    expect(stats.updated_at).not_to be_nil
+  end
+end

--- a/spec/gcs_bucket_spec.rb
+++ b/spec/gcs_bucket_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+require 'google/cloud/storage'
+
+class GCSCloud < AssetCloud::Base
+end
+
+class MockGCSBucket < AssetCloud::GCSBucket
+  def files(prefix: nil)
+  end
+
+  def file(key)
+  end
+
+  def create_file(data, key)
+  end
+end
+
+describe AssetCloud::GCSBucket do
+  directory = File.dirname(__FILE__) + '/files'
+
+  before(:all) do
+    @cloud = GCSCloud.new(directory, '/assets/files')
+    @bucket = MockGCSBucket.new(@cloud, '')
+  end
+
+  it "#ls with no arguments returns all files in the bucket" do
+    expect_any_instance_of(GCSCloud).to receive(:gcs_bucket).and_return(@bucket)
+    expect_any_instance_of(MockGCSBucket).to receive(:files).with(no_args).and_return(nil)
+    @bucket.ls
+  end
+
+  it "#ls with arguments returns the file" do
+    key = 'test/ls.txt'
+    expect_any_instance_of(MockGCSBucket).to receive(:file).with("s#{@cloud.url}/#{key}").and_return(Google::Cloud::Storage::File.new)
+
+    file = @bucket.ls(key)
+    expect(file.class).to eq(Google::Cloud::Storage::File)
+  end
+
+  it "#write writes a file into the bucket" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/key.txt'
+    expect_any_instance_of(MockGCSBucket).to receive(:create_file).with(local_path, "s#{@cloud.url}/#{key}")
+
+    @bucket.write(key, local_path)
+  end
+
+  it "#delete removes the file from the bucket" do
+    key = 'test/key.txt'
+    expect_any_instance_of(MockGCSBucket).to receive(:file).with("s#{@cloud.url}/#{key}").and_return(Google::Cloud::Storage::File.new)
+    expect_any_instance_of(Google::Cloud::Storage::File).to receive(:delete).with(no_args)
+
+    expect do
+      @bucket.delete(key)
+    end.not_to raise_error
+  end
+
+  it "#read returns the data of the file" do
+    value = 'hello world'
+    key = 'tmp/new_file.txt'
+    expect_any_instance_of(MockGCSBucket).to receive(:file).with("s#{@cloud.url}/#{key}").and_return(Google::Cloud::Storage::File.new)
+    expect_any_instance_of(Google::Cloud::Storage::File).to receive(:download).and_return(StringIO.new(value))
+
+    data = @bucket.read(key)
+    data.should == value
+  end
+
+  it "#read raises AssetCloud::AssetNotFoundError if the file is not found" do
+    key = 'tmp/not_found.txt'
+    expect_any_instance_of(MockGCSBucket).to receive(:file).with("s#{@cloud.url}/#{key}").and_return(nil)
+    expect do
+      @bucket.read(key)
+    end.to raise_error(AssetCloud::AssetNotFoundError)
+  end
+
+  it "#stat returns information on the asset" do
+    value = 'hello world'
+    key = 'tmp/new_file.txt'
+    expected_time = Time.now
+    expected_size = 1
+
+    expect_any_instance_of(MockGCSBucket).to receive(:file).with("s#{@cloud.url}/#{key}").and_return(Google::Cloud::Storage::File.new)
+    expect_any_instance_of(Google::Cloud::Storage::File).to receive(:size).and_return(expected_size)
+    expect_any_instance_of(Google::Cloud::Storage::File).to receive(:created_at).and_return(expected_time)
+    expect_any_instance_of(Google::Cloud::Storage::File).to receive(:updated_at).and_return(expected_time)
+
+    stats = @bucket.stat(key)
+    expect(stats.size).to eq(expected_size)
+    expect(stats.created_at).to eq(expected_time)
+    expect(stats.updated_at).to eq(expected_time)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,4 @@ require 'active_support/all'
 $:<< File.dirname(__FILE__) + "/../lib"
 require 'asset_cloud'
 require 'asset_cloud/buckets/s3_bucket'
+require 'asset_cloud/buckets/gcs_bucket'


### PR DESCRIPTION
This PR adds the bucket and will allow us to upload directly into a GCS bucket.

I did not add all methods to the GCS bucket yet, the goal is to slowly roll this out so that we can upload images first and then we increment on top of that.

For testing, I used created my own bucket on GCS. To run the remote tests, you can create your own bucket and download your credential locally. You can then run them with the following command: `GCS_PROJECT_ID="<project_id>" GCS_KEY_FILEPATH="<path_to_key>" GCS_BUCKET="<bucket_name>" bundle exec rake spec`