### PR TITLE
[GCSBucket] Add options for GCSBucket

### DIFF
--- a/lib/asset_cloud/buckets/gcs_bucket.rb
+++ b/lib/asset_cloud/buckets/gcs_bucket.rb
@@ -13,8 +13,12 @@ module AssetCloud
       downloaded.read
     end
 
-    def write(key, data)
-      bucket.create_file(data, absolute_key(key))
+    def write(key, data, options = {})
+      bucket.create_file(
+        data,
+        absolute_key(key),
+        options
+      )
     end
 
     def delete(key)

--- a/spec/gcs_bucket_remote_spec.rb
+++ b/spec/gcs_bucket_remote_spec.rb
@@ -54,6 +54,35 @@ describe AssetCloud::GCSBucket, if: ENV['GCS_PROJECT_ID'] && ENV['GCS_KEY_FILEPA
     @bucket.write(key, local_path)
   end
 
+  it "#write writes a file into the bucket with metadata" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/key.txt'
+    metadata = {
+      "X-Robots-Tag" => "none"
+    }
+
+    file = @bucket.write(key, local_path, metadata: metadata)
+    expect(file.metadata).to eq(metadata)
+  end
+
+  it "#write writes a file into the bucket with acl" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/key.txt'
+    acl = 'public'
+
+    file = @bucket.write(key, local_path, acl: acl)
+    expect(file.acl).to be_truthy
+  end
+
+  it "#write writes a file into the bucket with content_disposition" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/key.txt'
+    content_disposition = 'attachment'
+
+    file = @bucket.write(key, local_path, content_disposition: content_disposition)
+    expect(file.content_disposition).to eq(content_disposition)
+  end
+
   it "#delete removes the file from the bucket" do
     key = 'test/key.txt'
 

--- a/spec/gcs_bucket_spec.rb
+++ b/spec/gcs_bucket_spec.rb
@@ -11,7 +11,7 @@ class MockGCSBucket < AssetCloud::GCSBucket
   def file(key)
   end
 
-  def create_file(data, key)
+  def create_file(data, key, options = {})
   end
 end
 
@@ -40,9 +40,54 @@ describe AssetCloud::GCSBucket do
   it "#write writes a file into the bucket" do
     local_path = "#{directory}/products/key.txt"
     key = 'test/key.txt'
-    expect_any_instance_of(MockGCSBucket).to receive(:create_file).with(local_path, "s#{@cloud.url}/#{key}")
+    expect_any_instance_of(MockGCSBucket).to receive(:create_file).with(
+      local_path,
+      "s#{@cloud.url}/#{key}",
+      {}
+    )
 
     @bucket.write(key, local_path)
+  end
+
+  it "#write writes a file into the bucket with metadata" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/key.txt'
+    metadata = {
+      "X-Robots-Tag" => "none"
+    }
+    expect_any_instance_of(MockGCSBucket).to receive(:create_file).with(
+      local_path,
+      "s#{@cloud.url}/#{key}",
+      metadata: metadata
+    )
+
+    @bucket.write(key, local_path, metadata: metadata)
+  end
+
+  it "#write writes a file into the bucket with acl" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/key.txt'
+    acl = 'public'
+    expect_any_instance_of(MockGCSBucket).to receive(:create_file).with(
+      local_path,
+      "s#{@cloud.url}/#{key}",
+      acl: acl
+    )
+
+    @bucket.write(key, local_path, acl: acl)
+  end
+
+  it "#write writes a file into the bucket with content_disposition" do
+    local_path = "#{directory}/products/key.txt"
+    key = 'test/key.txt'
+    content_disposition = 'attachment'
+    expect_any_instance_of(MockGCSBucket).to receive(:create_file).with(
+      local_path,
+      "s#{@cloud.url}/#{key}",
+      content_disposition: content_disposition
+    )
+
+    @bucket.write(key, local_path, content_disposition: content_disposition)
   end
 
   it "#delete removes the file from the bucket" do


### PR DESCRIPTION
Allow optional arguments when writing a file into the bucket.

All options are available here: https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-storage/lib/google/cloud/storage/bucket.rb#L1247-L1252