### PR TITLE
Fix callback lifecycle

### DIFF
--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -41,8 +41,8 @@ AssetCloud::Asset.class_eval do
   validate :valid_key
 
   def execute_callbacks(symbol, args)
-    super
-    @extensions.each {|ext| ext.execute_callbacks(symbol, args)}
+    result = super
+    result && @extensions.all? { |ext| ext.execute_callbacks(symbol, args) }
   end
 
   protected

--- a/lib/asset_cloud/callbacks.rb
+++ b/lib/asset_cloud/callbacks.rb
@@ -27,7 +27,7 @@ module AssetCloud
           result = nil
           if execute_callbacks(before, args)
             result = super(*args, &block)
-            execute_callbacks(after, args)
+            execute_callbacks(after, args) if result
           end
           result
         end

--- a/spec/callbacks_spec.rb
+++ b/spec/callbacks_spec.rb
@@ -32,6 +32,9 @@ class CallbackCloud < AssetCloud::Base
 
   after_write :callback_after_write
   before_write :callback_before_write
+
+  def callback_before_write(*args); end
+  def callback_after_write(*args); end
 end
 
 class MethodRecordingCloud < AssetCloud::Base
@@ -48,21 +51,25 @@ class MethodRecordingCloud < AssetCloud::Base
 end
 
 describe CallbackCloud do
-  before { @fs = CallbackCloud.new(File.dirname(__FILE__) + '/files', 'http://assets/') }
+  before do
+    @fs = CallbackCloud.new(File.dirname(__FILE__) + '/files', 'http://assets/')
+    @fs.write('tmp/file.txt', 'foo')
+  end
 
   it "should invoke callbacks after store" do
     @fs.should_receive(:callback_before_write).with('tmp/file.txt', 'text').and_return(true)
     @fs.should_receive(:callback_after_write).with('tmp/file.txt', 'text').and_return(true)
 
 
-    @fs.write 'tmp/file.txt', 'text'
+    @fs.write('tmp/file.txt', 'text').should == true
+    @fs.read('tmp/file.txt').should == 'text'
   end
 
   it "should invoke callbacks after delete" do
     @fs.should_receive(:callback_before_delete).with('tmp/file.txt').and_return(true)
     @fs.should_receive(:callback_after_delete).with('tmp/file.txt').and_return(true)
 
-    @fs.delete 'tmp/file.txt'
+    @fs.delete('tmp/file.txt').should == 'foo'
   end
 
   it "should invoke callbacks even when constructing a new asset" do
@@ -72,7 +79,7 @@ describe CallbackCloud do
 
     asset = @fs.build('tmp/file.txt')
     asset.value = 'hello'
-    asset.store
+    asset.store.should == true
   end
 end
 


### PR DESCRIPTION
I had attempted to use a `before_delete` callback off a class that inherited from `AssetCloud#asset` and have discovered it did not work as expected: returning `false` from a `before_` filter did not prevent further execution.

After investigation, I've noticed the callback chain was executed but it did not respect the return value. So it was entirely possible for a before filter like mine to return 'false' but to be sped through to completion as if it _was_ successful...

Before filters are crucial to stop proceeding when any one returns false. The function implementation that depends on it expects a truthy return value - already a problem because only 'nil', 'false' and 0 cause it to not enter the block. (see https://github.com/Shopify/asset_cloud/blob/385ec2634d29ad4cab51de8d0a0c8feef3bfe8bf/lib/asset_cloud/callbacks.rb/#L28).

I explicitly return a boolean from `#execute_callbacks`. And I prevent `after_*` callbacks from being executed when the main action fails (i.e I don't execute `after_delete` when `delete` fails)