### PR TITLE
Fixing `Asset`'s `<=>` method

### DIFF
--- a/lib/asset_cloud/asset.rb
+++ b/lib/asset_cloud/asset.rb
@@ -34,7 +34,13 @@ module AssetCloud
     end
 
     def <=>(other)
-      cloud.object_id <=> other.cloud.object_id && key <=> other.key
+      return 1 unless other.is_a?(Asset)
+      compare_cloud = cloud.object_id <=> other.cloud.object_id
+      if compare_cloud == 0
+        key <=> other.key
+      else
+        compare_cloud
+      end
     end
 
     def new_asset?

--- a/spec/asset_spec.rb
+++ b/spec/asset_spec.rb
@@ -173,5 +173,43 @@ describe "Asset" do
     end
   end
 
+  describe "comparable" do
+    before do
+      @key = "products/key.txt"
+      @asset = AssetCloud::Asset.new(@cloud, @key)
+    end
 
+    context "comparing to instance of Asset class" do
+      it "is equal if cloud and key of both assets are equal" do
+        other_asset = AssetCloud::Asset.new(@cloud, @key)
+
+        expect(@asset == other_asset).to eq(true)
+      end
+
+      it "is not equal if cloud of both assets are not equal" do
+        other_cloud = double('Cloud2', :asset_extension_classes_for_bucket => [], :object_id => 999)
+        other_asset = AssetCloud::Asset.new(other_cloud, @key)
+
+        expect(@asset == other_asset).to eq(false)
+      end
+
+      it "is not equal if key of both assets are not equal" do
+        other_key = "products/other_key.txt"
+        other_asset = AssetCloud::Asset.new(@cloud, other_key)
+
+        expect(@asset == other_asset).to eq(false)
+      end
+    end
+
+    context "comparing to instance of non-Asset class" do
+      it "is not equal to a non-Asset object" do
+        AssetCloud::Asset.new(@cloud, "products/foo, bar.txt", "data")
+
+        expect(@asset == "some_string").to eq(false)
+        expect(@asset == :some_symbol).to eq(false)
+        expect(@asset == []).to eq(false)
+        expect(@asset == nil).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Related issue
https://github.com/Shopify/shopify/issues/233260

# Description
Fixing `Asset`'s `<=>` method to work correctly when used for comparing (`==`) with instances of other classes.

Adding tests to cover different edge cases.
Previous implementation would fail if comparing Asset object with any other object which doesn't respond to `cloud` and `key` methods.
Additionally we used logical `AND` to combine check for `cloud` and `key`. This would work fine if the comparison would be done via `==`,
but with `<=>` we are getting number back (-1, 0, or 1), so combining these via logical `AND` was producing unexpected results.