### PR TITLE
Bump gem version to 2.3.0

### DIFF
--- a/asset_cloud.gemspec
+++ b/asset_cloud.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{asset_cloud}
-  s.version = "2.2.9"
+  s.version = "2.3.0"
 
   s.authors = %w(Shopify)
   s.summary = %q{An abstraction layer around arbitrary and diverse asset stores.}


### PR DESCRIPTION
Bumping version to publish gem with changes implemented in https://github.com/Shopify/asset_cloud/pull/47

Changing behaviour of `Asset.<=>` method.