### PR TITLE
Remove the code that checks for `cloud.object_id` when comparing Asset objects.

### DIFF
--- a/lib/asset_cloud/asset.rb
+++ b/lib/asset_cloud/asset.rb
@@ -35,12 +35,7 @@ module AssetCloud
 
     def <=>(other)
       return 1 unless other.is_a?(Asset)
-      compare_cloud = cloud.object_id <=> other.cloud.object_id
-      if compare_cloud == 0
-        key <=> other.key
-      else
-        compare_cloud
-      end
+      key <=> other.key
     end
 
     def new_asset?

--- a/lib/asset_cloud/asset.rb
+++ b/lib/asset_cloud/asset.rb
@@ -34,7 +34,7 @@ module AssetCloud
     end
 
     def <=>(other)
-      return 1 unless other.is_a?(Asset)
+      return 1 unless other.respond_to?(:key)
       key <=> other.key
     end
 

--- a/lib/asset_cloud/asset.rb
+++ b/lib/asset_cloud/asset.rb
@@ -34,8 +34,7 @@ module AssetCloud
     end
 
     def <=>(other)
-      return 1 unless other.respond_to?(:key)
-      key <=> other.key
+      key <=> other.try(:key)
     end
 
     def new_asset?

--- a/spec/asset_spec.rb
+++ b/spec/asset_spec.rb
@@ -202,6 +202,11 @@ describe "Asset" do
         expect(@asset == :some_symbol).to eq(false)
         expect(@asset == []).to eq(false)
         expect(@asset == nil).to eq(false)
+
+        expect(@asset <=> "some_string").to eq(nil)
+        expect(@asset <=> :some_symbol).to eq(nil)
+        expect(@asset <=> []).to eq(nil)
+        expect(@asset <=> nil).to eq(nil)
       end
     end
   end

--- a/spec/asset_spec.rb
+++ b/spec/asset_spec.rb
@@ -186,13 +186,6 @@ describe "Asset" do
         expect(@asset == other_asset).to eq(true)
       end
 
-      it "is not equal if cloud of both assets are not equal" do
-        other_cloud = double('Cloud2', :asset_extension_classes_for_bucket => [], :object_id => 999)
-        other_asset = AssetCloud::Asset.new(other_cloud, @key)
-
-        expect(@asset == other_asset).to eq(false)
-      end
-
       it "is not equal if key of both assets are not equal" do
         other_key = "products/other_key.txt"
         other_asset = AssetCloud::Asset.new(@cloud, other_key)


### PR DESCRIPTION
# Description
This is a "continuation" from https://github.com/Shopify/asset_cloud/pull/47
We kept the old logic and fixed a logical error which made the comparison more strict.
Old logic:
```Ruby
def <=>(other)
  cloud.object_id <=> other.cloud.object_id && key <=> other.key
end
```
Because `cloud.object_id <=> other.cloud.object_id` returns an Integer (-1, 0 or 1) Ruby evaluates it to `true` every time, then we have `&&` which means we always go to the next condition `key <=> other.key`.

We are removing the `cloud.object_id <=> other.cloud.object_id` as it is not affecting the logic.
New logic:
```Ruby
def <=>(other)
  key <=> other.try(:key)
end
```