### PR TITLE
Add `create` and `update` callback

### DIFF
--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -29,7 +29,7 @@ require 'asset_cloud/asset_extension'
 AssetCloud::Base.class_eval do
   include AssetCloud::FreeKeyLocator
   include AssetCloud::Callbacks
-  callback_methods :write, :delete
+  callback_methods :create, :update, :write, :delete
 end
 
 AssetCloud::Asset.class_eval do


### PR DESCRIPTION
We currently use the `after_write` callback for assets when they are created or updated. This PR adds the callbacks for `create` and `update`.

The `write` callback currently exists but we would need to separate `create` and `update` for our usage.