### PR TITLE
Drop support for ruby < 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 before_install:
   - gem install bundler
 rvm:
-  - '2.3'
+  - '2.5'
   - '2.6'

--- a/asset_cloud.gemspec
+++ b/asset_cloud.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary = %q{An abstraction layer around arbitrary and diverse asset stores.}
   s.description = %q{An abstraction layer around arbitrary and diverse asset stores.}
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.email = %q{developers@shopify.com}
   s.homepage = %q{http://github.com/Shopify/asset_cloud}

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: asset-cloud
 
 up:
   - ruby:
-      version: 2.3.3
+      version: 2.5.0
   - bundler
 
 commands:


### PR DESCRIPTION
`pry-byebug` does not work with ruby 2.3.3.

We think it's time to update the requirements for the gem.

