### PR TITLE
Stop using URI.encode since it is deprecated

### DIFF
--- a/asset_cloud.gemspec
+++ b/asset_cloud.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   s.add_dependency 'activesupport'
+  s.add_dependency 'addressable'
 
   s.metadata['allowed_push_host'] = "https://rubygems.org"
 

--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -1,3 +1,4 @@
+require 'addressable'
 require 'active_support'
 
 # Core

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -1,5 +1,3 @@
-require 'uri'
-
 module AssetCloud
 
   class IllegalPath < StandardError
@@ -93,7 +91,7 @@ module AssetCloud
     end
 
     def url_for(key, options={})
-      File.join(@url, URI.encode(key))
+      File.join(@url, Addressable::URI.encode_component(key, Addressable::URI::CharacterClasses::PATH))
     end
 
     def path_for(key)


### PR DESCRIPTION
It's deprecated since Ruby 1.9, and since 2.7 it will always print a warning regardless of the verbosity level.

It's a bit tricky to replace, as it's never clear what it's supposed to escape or not. There are several alternatives in the stdlib, but none does escape exactly what we want here, namely the PATH component of the URI.

So I added `addressable` as a dependency, it's a very popular gem, so most likely not really an extra dependency.