### PR TITLE
Use Addressable::URI.escape in url_for

### DIFF
--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -91,7 +91,7 @@ module AssetCloud
     end
 
     def url_for(key, options={})
-      File.join(@url, Addressable::URI.encode_component(key, Addressable::URI::CharacterClasses::PATH))
+      File.join(@url, Addressable::URI.escape(key))
     end
 
     def path_for(key)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -125,7 +125,7 @@ describe BasicCloud do
   end
 
   it "should compute complete urls to assets" do
-    @fs.url_for('products/key with spaces.txt').should == 'http://assets/files/products/key%20with%20spaces.txt'
+    @fs.url_for('products/key with spaces.txt?foo=1&bar=2').should == 'http://assets/files/products/key%20with%20spaces.txt?foo=1&bar=2'
   end
 
   describe "#find" do


### PR DESCRIPTION
Followup: https://github.com/Shopify/asset_cloud/pull/54

So turns out some code relies on query params not being escaped.

So my assumption on needing consider the key as a `PATH` component was wrong, it need to be considered as a `PATH_INFO` (path + query string).

I updated the test suite in accordance.