### PR TITLE
Now escape urls with URI::RFC2396_Parser#escape

### DIFF
--- a/asset_cloud.gemspec
+++ b/asset_cloud.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   s.add_dependency 'activesupport'
-  s.add_dependency 'addressable'
 
   s.metadata['allowed_push_host'] = "https://rubygems.org"
 

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -1,3 +1,5 @@
+require 'uri/rfc2396_parser'
+
 module AssetCloud
 
   class IllegalPath < StandardError
@@ -26,6 +28,8 @@ module AssetCloud
         )
       )\z/x
     MATCH_BUCKET = /^(\w+)(\/|$)/
+
+    URI_PARSER = URI::RFC2396_Parser.new
 
     attr_accessor :url, :root
 
@@ -91,7 +95,7 @@ module AssetCloud
     end
 
     def url_for(key, options={})
-      File.join(@url, Addressable::URI.escape(key))
+      File.join(@url, URI_PARSER.escape(key))
     end
 
     def path_for(key)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -125,7 +125,7 @@ describe BasicCloud do
   end
 
   it "should compute complete urls to assets" do
-    @fs.url_for('products/key with spaces.txt?foo=1&bar=2').should == 'http://assets/files/products/key%20with%20spaces.txt?foo=1&bar=2'
+    @fs.url_for('products/[key] with spaces.txt?foo=1&bar=2').should == 'http://assets/files/products/[key]%20with%20spaces.txt?foo=1&bar=2'
   end
 
   describe "#find" do


### PR DESCRIPTION
Followup: https://github.com/Shopify/asset_cloud/pull/55

Turns out `Addressable::URI.escape` causes issues, because while `[` and `]` should be escaped when in a path, some `asset_cloud` callers do rely on them not being escape.

At this stage, I think sticking to `URI.escape` is unfortunately the only thing to do...

So to avoid the warning I bypass the method itself and use the underlying construct.

It's documented and not marked as deprecated: https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI/RFC2396_Parser.html#method-i-escape (even though I find this a bit doubtful). 
