### PR TITLE
Update RSpec syntax

### DIFF
--- a/spec/active_record_bucket_spec.rb
+++ b/spec/active_record_bucket_spec.rb
@@ -25,43 +25,43 @@ describe AssetCloud::ActiveRecordBucket do
 
   describe '#ls' do
     before do
-      MockRecords.should_receive(:connection).and_return(@mock_connection = double("connection"))
-      @mock_connection.should_receive(:quote_column_name).with('name').and_return("`name`")
-      (@mock_record = double("record")).should_receive(:name).and_return('stuff/a1')
+      expect(MockRecords).to receive(:connection).and_return(@mock_connection = double("connection"))
+      expect(@mock_connection).to receive(:quote_column_name).with('name').and_return("`name`")
+      expect(@mock_record = double("record")).to receive(:name).and_return('stuff/a1')
     end
 
     it "should return a list of assets which start with the given prefix" do
-      MockRecords.should_receive(:all).with(:conditions => ["`name` LIKE ?", "stuff/a%"]).and_return([@mock_record])
+      expect(MockRecords).to receive(:all).with(:conditions => ["`name` LIKE ?", "stuff/a%"]).and_return([@mock_record])
 
-      @bucket.ls('stuff/a').size.should == 1
+      expect(@bucket.ls('stuff/a').size).to eq(1)
     end
 
     it "should return a list of all assets when a prefix is not given" do
-      MockRecords.should_receive(:all).with(:conditions => ["`name` LIKE ?", "stuff%"]).and_return([@mock_record])
+      expect(MockRecords).to receive(:all).with(:conditions => ["`name` LIKE ?", "stuff%"]).and_return([@mock_record])
 
-      @bucket.ls.size.should == 1
+      expect(@bucket.ls.size).to eq(1)
     end
   end
 
   describe '#read' do
     it "should return the value of a key when it exists" do
-      (@mock_record = double("record")).should_receive(:body).and_return('foo')
-      MockRecords.should_receive(:first).with(:conditions => {'name' => 'stuff/a1'}).and_return(@mock_record)
+      expect(@mock_record = double("record")).to receive(:body).and_return('foo')
+      expect(MockRecords).to receive(:first).with(:conditions => {'name' => 'stuff/a1'}).and_return(@mock_record)
 
       @bucket.read('stuff/a1')
     end
     it "should raise AssetNotFoundError when nothing is there" do
-      MockRecords.should_receive(:first).with(:conditions => {'name' => 'stuff/a1'}).and_return(nil)
+      expect(MockRecords).to receive(:first).with(:conditions => {'name' => 'stuff/a1'}).and_return(nil)
 
-      lambda {@bucket.read('stuff/a1')}.should raise_error(AssetCloud::AssetNotFoundError)
+      expect {@bucket.read('stuff/a1')}.to raise_error(AssetCloud::AssetNotFoundError)
     end
   end
 
   describe '#write' do
     it "should write to the DB" do
-      (@mock_record = double("record")).should_receive(:body=).with('foo').and_return('foo')
-      @mock_record.should_receive(:save!).and_return(true)
-      MockRecords.should_receive(:find_or_initialize_by_name).with('stuff/a1').and_return(@mock_record)
+      expect(@mock_record = double("record")).to receive(:body=).with('foo').and_return('foo')
+      expect(@mock_record).to receive(:save!).and_return(true)
+      expect(MockRecords).to receive(:find_or_initialize_by_name).with('stuff/a1').and_return(@mock_record)
 
       @bucket.write('stuff/a1', 'foo')
     end
@@ -69,8 +69,8 @@ describe AssetCloud::ActiveRecordBucket do
 
   describe '#delete' do
     it "should destroy records" do
-      (@mock_record = double("record")).should_receive(:destroy).and_return(true)
-      MockRecords.should_receive(:first).with(:conditions => {'name' => 'stuff/a1'}).and_return(@mock_record)
+      expect(@mock_record = double("record")).to receive(:destroy).and_return(true)
+      expect(MockRecords).to receive(:first).with(:conditions => {'name' => 'stuff/a1'}).and_return(@mock_record)
 
       @bucket.delete('stuff/a1')
     end
@@ -78,15 +78,15 @@ describe AssetCloud::ActiveRecordBucket do
 
   describe '#stat' do
     it "should return appropriate metadata" do
-      (@mock_record = double("record")).should_receive(:created_at).and_return(1982)
-      @mock_record.should_receive(:updated_at).and_return(2002)
-      @mock_record.should_receive(:body).and_return('foo')
-      MockRecords.should_receive(:first).with(:conditions => {'name' => 'stuff/a1'}).and_return(@mock_record)
+      expect(@mock_record = double("record")).to receive(:created_at).and_return(1982)
+      expect(@mock_record).to receive(:updated_at).and_return(2002)
+      expect(@mock_record).to receive(:body).and_return('foo')
+      expect(MockRecords).to receive(:first).with(:conditions => {'name' => 'stuff/a1'}).and_return(@mock_record)
 
       metadata = @bucket.stat('stuff/a1')
-      metadata.created_at.should == 1982
-      metadata.updated_at.should == 2002
-      metadata.size.should == 3
+      expect(metadata.created_at).to eq(1982)
+      expect(metadata.updated_at).to eq(2002)
+      expect(metadata.size).to eq(3)
     end
   end
 

--- a/spec/asset_extension_spec.rb
+++ b/spec/asset_extension_spec.rb
@@ -55,7 +55,7 @@ describe "AssetExtension" do
   describe "applicability" do
     it "should work" do
       asset = @cloud['cat_pen/cats.xml']
-      XmlAssetExtension.applies_to_asset?(asset).should == true
+      expect(XmlAssetExtension.applies_to_asset?(asset)).to eq(true)
     end
   end
 
@@ -63,31 +63,31 @@ describe "AssetExtension" do
     it "should be added to assets in the right bucket with the right extension" do
       asset = @cloud['cat_pen/cats.css']
       asset.value = 'foo'
-      asset.store.should == false
-      asset.errors.should == ["not enough curly brackets!"]
+      expect(asset.store).to eq(false)
+      expect(asset.errors).to eq(["not enough curly brackets!"])
     end
 
     it "should not squash existing validations on the asset" do
       asset = @cloud['dog_pound/cats.xml']
       asset.value = 'cats!'
-      asset.store.should == false
-      asset.errors.should == ['no cats allowed!', "not enough angle brackets!"]
+      expect(asset.store).to eq(false)
+      expect(asset.errors).to eq(['no cats allowed!', "not enough angle brackets!"])
     end
 
     it "should not apply to non-matching assets or those in exempted buckets" do
       asset = @cloud['cat_pen/cats.xml']
       asset.value = "xml"
-      asset.store.should == true
+      expect(asset.store).to eq(true)
     end
   end
 
   describe "callbacks" do
     it "should run alongside the asset's callbacks" do
       asset = @cloud['dog_pound/dogs.xml']
-      asset.should_receive(:asset_callback)
-      asset.extensions.first.should_receive(:xml_callback)
+      expect(asset).to receive(:asset_callback)
+      expect(asset.extensions.first).to receive(:xml_callback)
       asset.value = '<dogs/>'
-      asset.store.should == true
+      expect(asset.store).to eq(true)
     end
   end
 
@@ -96,7 +96,7 @@ describe "AssetExtension" do
       asset = @cloud['dog_pound/dogs.xml']
       asset.value = 'dogs'
       asset.turn_into_xml
-      asset.value.should == '<xml>dogs</xml>'
+      expect(asset.value).to eq('<xml>dogs</xml>')
     end
 
     it "does not swallow NotImplementedError" do

--- a/spec/asset_spec.rb
+++ b/spec/asset_spec.rb
@@ -13,64 +13,64 @@ describe "Asset" do
     end
 
     it "should be return new_asset? => true" do
-      @asset.new_asset?.should == true
+      expect(@asset.new_asset?).to eq(true)
     end
 
     it "should have a key" do
-      @asset.key.should == 'products/key.txt'
+      expect(@asset.key).to eq('products/key.txt')
     end
 
     it "should have a value of nil" do
 
-      @asset.value.should == nil
+      expect(@asset.value).to eq(nil)
     end
 
     it "should have a basename" do
-      @asset.basename.should == 'key.txt'
+      expect(@asset.basename).to eq('key.txt')
     end
 
     it "should have a basename without ext (if required)" do
-      @asset.basename_without_ext.should == 'key'
+      expect(@asset.basename_without_ext).to eq('key')
     end
 
     it "should have an ext" do
-      @asset.extname.should == '.txt'
+      expect(@asset.extname).to eq('.txt')
     end
 
     it "should have a relative_key_without_ext" do
-      @asset.relative_key_without_ext.should == 'key'
+      expect(@asset.relative_key_without_ext).to eq('key')
     end
 
     it "should have a bucket_name" do
-      @asset.bucket_name.should == 'products'
+      expect(@asset.bucket_name).to eq('products')
     end
 
     it "should have a bucket" do
-      @cloud.should_receive(:buckets).and_return(:products => :products_bucket)
-      @asset.bucket.should == :products_bucket
+      expect(@cloud).to receive(:buckets).and_return(:products => :products_bucket)
+      expect(@asset.bucket).to eq(:products_bucket)
     end
 
     it "should store data to the bucket" do
-      @cloud.should_receive(:write).with("products/key.txt", 'value')
+      expect(@cloud).to receive(:write).with("products/key.txt", 'value')
 
       @asset.value = 'value'
       @asset.store
     end
 
     it "should not try to store data when it's value is nil" do
-      @cloud.should_receive(:write).never
+      expect(@cloud).to receive(:write).never
 
       @asset.store
     end
 
     it "should not try to read data from bucket if its a new_asset" do
-      @cloud.should_receive(:read).never
+      expect(@cloud).to receive(:read).never
 
-      @asset.value.should == nil
+      expect(@asset.value).to eq(nil)
     end
 
     it "should simply ignore calls to delete" do
-      @cloud.should_receive(:delete).never
+      expect(@cloud).to receive(:delete).never
 
       @asset.delete
     end
@@ -84,11 +84,11 @@ describe "Asset" do
     end
 
     it "should have a relative_key_without_ext" do
-      @asset.relative_key_without_ext.should == 'retail/key'
+      expect(@asset.relative_key_without_ext).to eq('retail/key')
     end
 
     it "should have a relative_key" do
-      @asset.relative_key.should == 'retail/key.txt'
+      expect(@asset.relative_key).to eq('retail/key.txt')
     end
   end
 
@@ -99,27 +99,27 @@ describe "Asset" do
     end
 
     it "should be return new_asset? => true" do
-      @asset.new_asset?.should == true
+      expect(@asset.new_asset?).to eq(true)
     end
 
 
     it "should have a value of 'value'" do
-      @asset.value.should == 'value'
+      expect(@asset.value).to eq('value')
     end
 
     it "should return false when asked if it exists because its still a new_asset" do
-      @asset.exist?.should == false
+      expect(@asset.exist?).to eq(false)
     end
 
 
     it "should not try to read data from bucket if its a new_asset" do
-      @cloud.should_receive(:read).never
+      expect(@cloud).to receive(:read).never
 
-      @asset.value.should == 'value'
+      expect(@asset.value).to eq('value')
     end
 
     it "should write data to the bucket" do
-      @cloud.should_receive(:write).with("products/key.txt", 'value')
+      expect(@cloud).to receive(:write).with("products/key.txt", 'value')
       @asset.store
     end
 
@@ -131,45 +131,45 @@ describe "Asset" do
     end
 
     it "should be return new_asset? => false" do
-      @asset.new_asset?.should == false
+      expect(@asset.new_asset?).to eq(false)
     end
 
     it "should indicate that it exists" do
 
-      @asset.exist?.should == true
+      expect(@asset.exist?).to eq(true)
     end
 
 
     it "should read the value from the bucket" do
-      @asset.value.should == 'value'
+      expect(@asset.value).to eq('value')
     end
 
 
     it "should simply ignore calls to delete" do
-      @cloud.should_receive(:delete).and_return(true)
+      expect(@cloud).to receive(:delete).and_return(true)
 
       @asset.delete
     end
 
     it "should ask the bucket to create a full url" do
-      @cloud.should_receive(:url_for).with('products/key.txt', {}).and_return('http://assets/products/key.txt')
+      expect(@cloud).to receive(:url_for).with('products/key.txt', {}).and_return('http://assets/products/key.txt')
 
-      @asset.url.should == 'http://assets/products/key.txt'
+      expect(@asset.url).to eq('http://assets/products/key.txt')
     end
 
     it "should ask the bucket whether or not it is versioned" do
       bucket = double('Bucket')
-      @cloud.should_receive(:buckets).and_return(:products => bucket)
-      bucket.should_receive(:versioned?).and_return(true)
+      expect(@cloud).to receive(:buckets).and_return(:products => bucket)
+      expect(bucket).to receive(:versioned?).and_return(true)
 
-      @asset.versioned?.should == true
+      expect(@asset.versioned?).to eq(true)
     end
 
     it "should validate its key" do
       asset = AssetCloud::Asset.new(@cloud, "products/foo, bar.txt", "data")
-      asset.store.should == false
-      asset.errors.size.should == 1
-      asset.errors.first.should =~ /illegal characters/
+      expect(asset.store).to eq(false)
+      expect(asset.errors.size).to eq(1)
+      expect(asset.errors.first).to match(/illegal characters/)
     end
   end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -21,67 +21,67 @@ describe BasicCloud do
   end
 
   it "should raise invalid bucket if none is given" do
-    @fs['image.jpg'].exist?.should == false
+    expect(@fs['image.jpg'].exist?).to eq(false)
   end
 
 
   it "should be backed by a file system bucket" do
-    @fs['products/key.txt'].exist?.should == true
+    expect(@fs['products/key.txt'].exist?).to eq(true)
   end
 
   it "should raise when listing non existing buckets" do
-    @fs.ls('products').should == [AssetCloud::Asset.new(@fs, 'products/key.txt')]
+    expect(@fs.ls('products')).to eq([AssetCloud::Asset.new(@fs, 'products/key.txt')])
   end
 
 
   it "should allow you to create new assets" do
     obj = @fs.build('new_file.test')
-    obj.should be_an_instance_of(AssetCloud::Asset)
-    obj.cloud.should be_an_instance_of(BasicCloud)
+    expect(obj).to be_an_instance_of(AssetCloud::Asset)
+    expect(obj.cloud).to be_an_instance_of(BasicCloud)
   end
 
   it "should raise error when using with minus relative or absolute paths" do
-    lambda { @fs['../test']  }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['/test']    }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['.../test'] }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['./test']   }.should raise_error(AssetCloud::IllegalPath)
+    expect { @fs['../test']  }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['/test']    }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['.../test'] }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['./test']   }.to raise_error(AssetCloud::IllegalPath)
   end
 
   it "should raise error when filename has trailing period" do
-    lambda { @fs['test.']             }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['/test/testfile.']   }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/directory/.']  }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['/test/testfile .']  }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/directory /.'] }.should raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test.']             }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['/test/testfile.']   }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/directory/.']  }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['/test/testfile .']  }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/directory /.'] }.to raise_error(AssetCloud::IllegalPath)
   end
 
   it "should raise error when filename ends with space" do
-    lambda { @fs['test ']             }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['/test/testfile ']   }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/directory/ ']  }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test. ']            }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['/test/testfile. ']  }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/directory/. '] }.should raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test ']             }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['/test/testfile ']   }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/directory/ ']  }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test. ']            }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['/test/testfile. ']  }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/directory/. '] }.to raise_error(AssetCloud::IllegalPath)
   end
 
   it "should raise error when filename ends with slash" do
-    lambda { @fs['test/']             }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/directory/']   }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test /']            }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['/test/testfile /']  }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/directory//']  }.should raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/']             }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/directory/']   }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test /']            }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['/test/testfile /']  }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/directory//']  }.to raise_error(AssetCloud::IllegalPath)
   end
 
   it "should raise error when using with minus relative even after another directory" do
-    lambda { @fs['test/../test']      }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/../../test']   }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test/../../../test']}.should raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/../test']      }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/../../test']   }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test/../../../test']}.to raise_error(AssetCloud::IllegalPath)
   end
 
   it "should raise an error when using names with combinations of '.' and ' '" do
-    lambda { @fs['test. . . .. ... .. . ']   }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test. .']   }.should raise_error(AssetCloud::IllegalPath)
-    lambda { @fs['test.   .test2']   }.should raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test. . . .. ... .. . ']   }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test. .']   }.to raise_error(AssetCloud::IllegalPath)
+    expect { @fs['test.   .test2']   }.to raise_error(AssetCloud::IllegalPath)
   end
 
   it "should allow filenames with repeating dots" do
@@ -125,40 +125,40 @@ describe BasicCloud do
   end
 
   it "should compute complete urls to assets" do
-    @fs.url_for('products/[key] with spaces.txt?foo=1&bar=2').should == 'http://assets/files/products/[key]%20with%20spaces.txt?foo=1&bar=2'
+    expect(@fs.url_for('products/[key] with spaces.txt?foo=1&bar=2')).to eq('http://assets/files/products/[key]%20with%20spaces.txt?foo=1&bar=2')
   end
 
   describe "#find" do
     it "should return the appropriate asset when one exists" do
       asset = @fs.find('products/key.txt')
-      asset.key.should == 'products/key.txt'
-      asset.value.should == 'value'
+      expect(asset.key).to eq('products/key.txt')
+      expect(asset.value).to eq('value')
     end
     it "should raise AssetNotFoundError when the asset doesn't exist" do
-      lambda { @fs.find('products/not-there.txt') }.should raise_error(AssetCloud::AssetNotFoundError)
+      expect { @fs.find('products/not-there.txt') }.to raise_error(AssetCloud::AssetNotFoundError)
     end
   end
 
   describe "#[]" do
     it "should return the appropriate asset when one exists" do
       asset = @fs['products/key.txt']
-      asset.key.should == 'products/key.txt'
-      asset.value.should == 'value'
+      expect(asset.key).to eq('products/key.txt')
+      expect(asset.value).to eq('value')
     end
     it "should not raise any errors when the asset doesn't exist" do
-      lambda { @fs['products/not-there.txt'] }.should_not raise_error
+      expect { @fs['products/not-there.txt'] }.not_to raise_error
     end
   end
 
   describe "#move" do
     it "should return move a resource" do
       asset = @fs['products/key.txt']
-      asset.key.should == 'products/key.txt'
-      asset.value.should == 'value'
+      expect(asset.key).to eq('products/key.txt')
+      expect(asset.value).to eq('value')
       @fs.move('products/key.txt', 'products/key2.txt')
       new_asset = @fs['products/key2.txt']
-      new_asset.key.should == 'products/key2.txt'
-      new_asset.value.should == 'value'
+      expect(new_asset.key).to eq('products/key2.txt')
+      expect(new_asset.value).to eq('value')
       expect {@fs['products/key.txt'].value }.to raise_error(AssetCloud::AssetNotFoundError)
       @fs.move('products/key2.txt', 'products/key.txt')
     end
@@ -167,25 +167,25 @@ describe BasicCloud do
   describe "#[]=" do
     it "should write through the Asset object (and thus run any callbacks on the asset)" do
       special_asset = double(:special_asset)
-      special_asset.should_receive(:value=).with('fancy fancy!')
-      special_asset.should_receive(:store)
-      SpecialAsset.should_receive(:at).and_return(special_asset)
+      expect(special_asset).to receive(:value=).with('fancy fancy!')
+      expect(special_asset).to receive(:store)
+      expect(SpecialAsset).to receive(:at).and_return(special_asset)
       @fs['special/fancy.txt'] = 'fancy fancy!'
     end
   end
 
   describe "#bucket" do
     it "should allow specifying a class to use for assets in this bucket" do
-      @fs['assets/rails_logo.gif'].should be_instance_of(AssetCloud::Asset)
-      @fs['special/fancy.txt'].should be_instance_of(SpecialAsset)
+      expect(@fs['assets/rails_logo.gif']).to be_instance_of(AssetCloud::Asset)
+      expect(@fs['special/fancy.txt']).to be_instance_of(SpecialAsset)
 
-      @fs.build('assets/foo').should be_instance_of(AssetCloud::Asset)
-      @fs.build('special/foo').should be_instance_of(SpecialAsset)
+      expect(@fs.build('assets/foo')).to be_instance_of(AssetCloud::Asset)
+      expect(@fs.build('special/foo')).to be_instance_of(SpecialAsset)
     end
 
     it "should allow specifying a proc that determines the class to use, using the default bucket when returning nil" do
-      @fs.build('conditional/default.js').should be_instance_of(AssetCloud::Asset)
-      @fs.build('conditional/better.liquid').should be_instance_of(LiquidAsset)
+      expect(@fs.build('conditional/default.js')).to be_instance_of(AssetCloud::Asset)
+      expect(@fs.build('conditional/better.liquid')).to be_instance_of(LiquidAsset)
     end
 
     it "should raise " do
@@ -197,16 +197,16 @@ describe BasicCloud do
     it "should match following stuff " do
 
       'products/key.txt' =~ AssetCloud::Base::MATCH_BUCKET
-      $1.should == 'products'
+      expect($1).to eq('products')
 
       'products/subpath/key.txt' =~ AssetCloud::Base::MATCH_BUCKET
-      $1.should == 'products'
+      expect($1).to eq('products')
 
       'key.txt' =~ AssetCloud::Base::MATCH_BUCKET
-      $1.should == nil
+      expect($1).to eq(nil)
 
       'products' =~ AssetCloud::Base::MATCH_BUCKET
-      $1.should == 'products'
+      expect($1).to eq('products')
     end
   end
 end

--- a/spec/blackhole_bucket_spec.rb
+++ b/spec/blackhole_bucket_spec.rb
@@ -16,12 +16,12 @@ describe BlackholeCloud do
   end
 
   it "should return nil for non existent files" do
-    @fs['tmp/image.jpg'].exist?.should == false
+    expect(@fs['tmp/image.jpg'].exist?).to eq(false)
   end
 
   it "should still return nil, even if you wrote something there" do
     @fs['tmp/image.jpg'] = 'test'
-    @fs['tmp/image.jpg'].exist?.should == false
+    expect(@fs['tmp/image.jpg'].exist?).to eq(false)
   end
 
   describe "when using a sub path" do
@@ -30,12 +30,12 @@ describe BlackholeCloud do
     end
 
     it "should return nil for non existent files" do
-      @fs['tmp/image.jpg'].exist?.should == false
+      expect(@fs['tmp/image.jpg'].exist?).to eq(false)
     end
 
     it "should still return nil, even if you wrote something there" do
       @fs['tmp/image.jpg'] = 'test'
-      @fs['tmp/image.jpg'].exist?.should == false
+      expect(@fs['tmp/image.jpg'].exist?).to eq(false)
     end
   end
 end

--- a/spec/bucket_chain_spec.rb
+++ b/spec/bucket_chain_spec.rb
@@ -24,35 +24,35 @@ describe AssetCloud::BucketChain do
 
   describe ".chain" do
     it 'should take multiple Bucket classes and return a new Bucket class' do
-      @bucket_chain.should be_a_kind_of(AssetCloud::BucketChain)
+      expect(@bucket_chain).to be_a_kind_of(AssetCloud::BucketChain)
     end
   end
 
   describe "#write" do
     it 'should write to each sub-bucket when everything is kosher and return the result of the first write' do
       @chained_buckets.each do |bucket|
-        bucket.should_receive(:write).with('stuff/foo', 'successful creation').and_return('successful creation')
+        expect(bucket).to receive(:write).with('stuff/foo', 'successful creation').and_return('successful creation')
       end
 
-      @bucket_chain.write('stuff/foo', 'successful creation').should == 'successful creation'
+      expect(@bucket_chain.write('stuff/foo', 'successful creation')).to eq('successful creation')
     end
     it 'should roll back creation-writes and re-raise an error when a bucket raises one' do
-      @chained_buckets.last.should_receive(:write).with('stuff/foo', 'unsuccessful creation').and_raise('hell')
+      expect(@chained_buckets.last).to receive(:write).with('stuff/foo', 'unsuccessful creation').and_raise('hell')
       @chained_buckets[0..-2].each do |bucket|
-        bucket.should_receive(:write).with('stuff/foo', 'unsuccessful creation').and_return(true)
-        bucket.should_receive(:delete).with('stuff/foo').and_return(true)
+        expect(bucket).to receive(:write).with('stuff/foo', 'unsuccessful creation').and_return(true)
+        expect(bucket).to receive(:delete).with('stuff/foo').and_return(true)
       end
 
-      lambda { @bucket_chain.write('stuff/foo', 'unsuccessful creation') }.should raise_error(RuntimeError)
+      expect { @bucket_chain.write('stuff/foo', 'unsuccessful creation') }.to raise_error(RuntimeError)
     end
     it 'should roll back update-writes and re-raise an error when a bucket raises one' do
       @bucket_chain.write('stuff/foo', "original value")
 
-      @chained_buckets.last.should_receive(:write).with('stuff/foo', 'new value').and_raise('hell')
+      expect(@chained_buckets.last).to receive(:write).with('stuff/foo', 'new value').and_raise('hell')
 
-      lambda { @bucket_chain.write('stuff/foo', 'new value') }.should raise_error(RuntimeError)
+      expect { @bucket_chain.write('stuff/foo', 'new value') }.to raise_error(RuntimeError)
       @chained_buckets.each do |bucket|
-        bucket.read('stuff/foo').should == 'original value'
+        expect(bucket.read('stuff/foo')).to eq('original value')
       end
     end
   end
@@ -62,7 +62,7 @@ describe AssetCloud::BucketChain do
       @bucket_chain.write('stuff/foo', "successful deletion comin' up")
 
       @chained_buckets.each do |bucket|
-        bucket.should_receive(:delete).with('stuff/foo').and_return(true)
+        expect(bucket).to receive(:delete).with('stuff/foo').and_return(true)
       end
 
       @bucket_chain.delete('stuff/foo')
@@ -70,35 +70,35 @@ describe AssetCloud::BucketChain do
     it 'should roll back deletions and re-raise an error when a bucket raises one' do
       @bucket_chain.write('stuff/foo', "this deletion will fail")
 
-      @chained_buckets.last.should_receive(:delete).with('stuff/foo').and_raise('hell')
+      expect(@chained_buckets.last).to receive(:delete).with('stuff/foo').and_raise('hell')
       @chained_buckets[0..-2].each do |bucket|
-        bucket.should_receive(:delete).with('stuff/foo').and_return(true)
-        bucket.should_receive(:write).with('stuff/foo', 'this deletion will fail').and_return(true)
+        expect(bucket).to receive(:delete).with('stuff/foo').and_return(true)
+        expect(bucket).to receive(:write).with('stuff/foo', 'this deletion will fail').and_return(true)
       end
 
-      lambda { @bucket_chain.delete('stuff/foo') }.should raise_error(RuntimeError)
+      expect { @bucket_chain.delete('stuff/foo') }.to raise_error(RuntimeError)
     end
   end
 
   describe "#read" do
     it 'should read from only the first available sub-bucket' do
-      @chained_buckets[0].should_receive(:read).with('stuff/foo').and_raise(NotImplementedError)
-      @chained_buckets[0].should_receive(:ls).with(nil).and_raise(NoMethodError)
-      @chained_buckets[0].should_receive(:stat).and_return(:metadata)
+      expect(@chained_buckets[0]).to receive(:read).with('stuff/foo').and_raise(NotImplementedError)
+      expect(@chained_buckets[0]).to receive(:ls).with(nil).and_raise(NoMethodError)
+      expect(@chained_buckets[0]).to receive(:stat).and_return(:metadata)
 
-      @chained_buckets[1].should_receive(:read).with('stuff/foo').and_return('bar')
-      @chained_buckets[1].should_receive(:ls).with(nil).and_return(:some_assets)
-      @chained_buckets[1].should_not_receive(:stat)
+      expect(@chained_buckets[1]).to receive(:read).with('stuff/foo').and_return('bar')
+      expect(@chained_buckets[1]).to receive(:ls).with(nil).and_return(:some_assets)
+      expect(@chained_buckets[1]).not_to receive(:stat)
 
       @chained_buckets[2..-1].each do |bucket|
-        bucket.should_not_receive(:read)
-        bucket.should_not_receive(:ls)
-        bucket.should_not_receive(:stat)
+        expect(bucket).not_to receive(:read)
+        expect(bucket).not_to receive(:ls)
+        expect(bucket).not_to receive(:stat)
       end
 
-      @bucket_chain.read('stuff/foo').should == 'bar'
-      @bucket_chain.ls.should == :some_assets
-      @bucket_chain.stat.should == :metadata
+      expect(@bucket_chain.read('stuff/foo')).to eq('bar')
+      expect(@bucket_chain.ls).to eq(:some_assets)
+      expect(@bucket_chain.stat).to eq(:metadata)
     end
   end
 
@@ -107,10 +107,10 @@ describe AssetCloud::BucketChain do
     it 'should read from only the first available sub-bucket' do
       buckets = @versioned_stuff.chained_buckets
 
-      buckets[1].should_receive(:read_version).with('stuff/foo',3).and_return('bar')
-      buckets.last.should_not_receive(:read_version)
+      expect(buckets[1]).to receive(:read_version).with('stuff/foo',3).and_return('bar')
+      expect(buckets.last).not_to receive(:read_version)
 
-      @versioned_stuff.read_version('stuff/foo', 3).should == 'bar'
+      expect(@versioned_stuff.read_version('stuff/foo', 3)).to eq('bar')
     end
   end
 
@@ -118,10 +118,10 @@ describe AssetCloud::BucketChain do
     it 'should read from only the first available sub-bucket' do
       buckets = @versioned_stuff.chained_buckets
 
-      buckets[1].should_receive(:versions).with('versioned_stuff/foo').and_return([1,2,3])
-      buckets.last.should_not_receive(:versions)
+      expect(buckets[1]).to receive(:versions).with('versioned_stuff/foo').and_return([1,2,3])
+      expect(buckets.last).not_to receive(:versions)
 
-      @versioned_stuff.versions('versioned_stuff/foo').should == [1,2,3]
+      expect(@versioned_stuff.versions('versioned_stuff/foo')).to eq([1,2,3])
     end
   end
 
@@ -131,28 +131,28 @@ describe AssetCloud::BucketChain do
         @cloud['versioned_stuff/foo'] = content
       end
       asset = @cloud['versioned_stuff/foo']
-      asset.value.should == 'three'
-      asset.rollback(1).value.should == 'one'
-      asset.versions.should == [1,2,3]
+      expect(asset.value).to eq('three')
+      expect(asset.rollback(1).value).to eq('one')
+      expect(asset.versions).to eq([1,2,3])
       asset.value = 'four'
       asset.store
-      asset.versions.should == [1,2,3,4]
+      expect(asset.versions).to eq([1,2,3,4])
     end
   end
 
   describe '#respond_to?' do
     it 'should return true if any chained buckets respond to the given method' do
-      @bucket_chain.respond_to?(:foo).should == false
-      @chained_buckets[1].should_receive(:respond_to?).with(:bar).and_return(true)
-      @bucket_chain.respond_to?(:bar).should == true
+      expect(@bucket_chain.respond_to?(:foo)).to eq(false)
+      expect(@chained_buckets[1]).to receive(:respond_to?).with(:bar).and_return(true)
+      expect(@bucket_chain.respond_to?(:bar)).to eq(true)
     end
   end
 
   describe '#method_missing' do
     it 'should try each bucket' do
-      @chained_buckets[1].should_receive(:buzz).and_return(true)
-      @chained_buckets[2].should_not_receive(:buzz)
-      @bucket_chain.buzz.should == true
+      expect(@chained_buckets[1]).to receive(:buzz).and_return(true)
+      expect(@chained_buckets[2]).not_to receive(:buzz)
+      expect(@bucket_chain.buzz).to eq(true)
     end
   end
 end

--- a/spec/callbacks_spec.rb
+++ b/spec/callbacks_spec.rb
@@ -62,38 +62,38 @@ describe CallbackCloud do
   end
 
   it "should invoke callbacks after store" do
-    @fs.should_receive(:callback_before_write).with('tmp/file.txt', 'text').and_return(true)
-    @fs.should_receive(:callback_after_write).with('tmp/file.txt', 'text').and_return(true)
+    expect(@fs).to receive(:callback_before_write).with('tmp/file.txt', 'text').and_return(true)
+    expect(@fs).to receive(:callback_after_write).with('tmp/file.txt', 'text').and_return(true)
 
 
-    @fs.write('tmp/file.txt', 'text').should == true
-    @fs.read('tmp/file.txt').should == 'text'
+    expect(@fs.write('tmp/file.txt', 'text')).to eq(true)
+    expect(@fs.read('tmp/file.txt')).to eq('text')
   end
 
   it "should invoke callbacks after delete" do
-    @fs.should_receive(:callback_before_delete).with('tmp/file.txt').and_return(true)
-    @fs.should_receive(:callback_after_delete).with('tmp/file.txt').and_return(true)
+    expect(@fs).to receive(:callback_before_delete).with('tmp/file.txt').and_return(true)
+    expect(@fs).to receive(:callback_after_delete).with('tmp/file.txt').and_return(true)
 
-    @fs.delete('tmp/file.txt').should == 'foo'
+    expect(@fs.delete('tmp/file.txt')).to eq('foo')
   end
 
   it "should not invoke other callbacks when a before_ filter returns false" do
-    @fs.should_receive(:callback_before_delete)
+    expect(@fs).to receive(:callback_before_delete)
       .with('tmp/file.txt')
       .and_return(false)
-    @fs.should_not_receive(:callback_after_delete)
+    expect(@fs).not_to receive(:callback_after_delete)
 
-    @fs.delete('tmp/file.txt').should == nil
+    expect(@fs.delete('tmp/file.txt')).to eq(nil)
   end
 
   it "should invoke callbacks even when constructing a new asset" do
-    @fs.should_receive(:callback_before_write).with('tmp/file.txt', 'hello').and_return(true)
-    @fs.should_receive(:callback_after_write).with('tmp/file.txt', 'hello').and_return(true)
+    expect(@fs).to receive(:callback_before_write).with('tmp/file.txt', 'hello').and_return(true)
+    expect(@fs).to receive(:callback_after_write).with('tmp/file.txt', 'hello').and_return(true)
 
 
     asset = @fs.build('tmp/file.txt')
     asset.value = 'hello'
-    asset.store.should == true
+    expect(asset.store).to eq(true)
   end
 end
 
@@ -105,12 +105,12 @@ describe MethodRecordingCloud do
 
   it 'should record event when invoked' do
     @fs.write('tmp/file.txt', 'random data')
-    @fs.run_callbacks.should == [:callback_before_write, :callback_before_write]
+    expect(@fs.run_callbacks).to eq([:callback_before_write, :callback_before_write])
   end
 
   it 'should record event when assignment operator is used' do
     @fs['tmp/file.txt'] = 'random data'
-    @fs.run_callbacks.should == [:callback_before_write, :callback_before_write]
+    expect(@fs.run_callbacks).to eq([:callback_before_write, :callback_before_write])
   end
 end
 
@@ -122,25 +122,25 @@ describe CallbackAsset do
   end
 
   it "should run before_validate, then validate, then after validate, then before_store, then store" do
-    @asset.should_receive(:callback_before_store).and_return(true)
-    @asset.should_not_receive(:callback_after_delete)
+    expect(@asset).to receive(:callback_before_store).and_return(true)
+    expect(@asset).not_to receive(:callback_after_delete)
 
     @asset.value = 'foo'
-    @asset.store.should == true
-    @asset.value.should == 'valid spice'
+    expect(@asset.store).to eq(true)
+    expect(@asset.value).to eq('valid spice')
   end
 
   it "should run its after_delete callback after delete is called" do
-    @asset.should_not_receive(:callback_before_store)
-    @asset.should_receive(:callback_after_delete).and_return(true)
+    expect(@asset).not_to receive(:callback_before_store)
+    expect(@asset).to receive(:callback_after_delete).and_return(true)
 
-    @asset.delete.should == 'bar'
+    expect(@asset.delete).to eq('bar')
   end
 
   it "not invoke other callbacks when a before_ filter returns false" do
-    @asset.should_receive(:callback_before_delete).and_return(false)
-    @asset.should_not_receive(:callback_after_delete)
+    expect(@asset).to receive(:callback_before_delete).and_return(false)
+    expect(@asset).not_to receive(:callback_after_delete)
 
-    @asset.delete.should == nil
+    expect(@asset.delete).to eq(nil)
   end
 end

--- a/spec/file_system_spec.rb
+++ b/spec/file_system_spec.rb
@@ -21,31 +21,31 @@ describe FileSystemCloud do
   end
 
   it "should use invalid bucket for random directories" do
-    @fs.bucket_for('does-not-exist/file.txt').should be_an_instance_of(AssetCloud::InvalidBucket)
+    expect(@fs.bucket_for('does-not-exist/file.txt')).to be_an_instance_of(AssetCloud::InvalidBucket)
   end
 
   it "should use filesystem bucket for products/ and tmp/  directories" do
-    @fs.bucket_for('products/file.txt').should be_an_instance_of(AssetCloud::FileSystemBucket)
-    @fs.bucket_for('tmp/file.txt').should be_an_instance_of(AssetCloud::FileSystemBucket)
+    expect(@fs.bucket_for('products/file.txt')).to be_an_instance_of(AssetCloud::FileSystemBucket)
+    expect(@fs.bucket_for('tmp/file.txt')).to be_an_instance_of(AssetCloud::FileSystemBucket)
   end
 
   it "should return Asset for existing files" do
-    @fs['products/key.txt'].exist?.should == true
-    @fs['products/key.txt'].should be_an_instance_of(AssetCloud::Asset)
+    expect(@fs['products/key.txt'].exist?).to eq(true)
+    expect(@fs['products/key.txt']).to be_an_instance_of(AssetCloud::Asset)
   end
 
   it "should be able to test if a file exists or not" do
-    @fs.stat('products/key.txt').exist?.should == true
-    @fs.stat('products/key2.txt').exist?.should == false
+    expect(@fs.stat('products/key.txt').exist?).to eq(true)
+    expect(@fs.stat('products/key2.txt').exist?).to eq(false)
   end
 
   it "should be able to list files" do
-    @fs.ls('products').collect(&:key).should == ['products/key.txt']
+    expect(@fs.ls('products').collect(&:key)).to eq(['products/key.txt'])
   end
 
   describe 'when modifying file system' do
     it "should call write after storing an asset" do
-      @fs.buckets[:tmp].should_receive(:write).with('tmp/new_file.test', 'hello world').and_return(true)
+      expect(@fs.buckets[:tmp]).to receive(:write).with('tmp/new_file.test', 'hello world').and_return(true)
 
       @fs.build('tmp/new_file.test', 'hello world').store
     end
@@ -53,20 +53,20 @@ describe FileSystemCloud do
     it "should be able to create new files" do
       @fs.build('tmp/new_file.test', 'hello world').store
 
-      @fs.stat('tmp/new_file.test').exist.should == true
+      expect(@fs.stat('tmp/new_file.test').exist).to eq(true)
     end
 
     it "should be able to create new files with simple assignment" do
       @fs['tmp/new_file.test'] = 'hello world'
 
-      @fs.stat('tmp/new_file.test').exist.should == true
+      expect(@fs.stat('tmp/new_file.test').exist).to eq(true)
     end
 
     it "should create directories as needed" do
       @fs.build('tmp/new_file.test', 'hello world').store
 
-      @fs['tmp/new_file.test'].exist?.should == true
-      @fs['tmp/new_file.test'].value.should == 'hello world'
+      expect(@fs['tmp/new_file.test'].exist?).to eq(true)
+      expect(@fs['tmp/new_file.test'].value).to eq('hello world')
     end
 
   end

--- a/spec/find_free_key_spec.rb
+++ b/spec/find_free_key_spec.rb
@@ -9,38 +9,38 @@ end
 describe "FreeFilenameLocator", 'when asked to return a free key such as the one passed in' do
 
   it "should simply return the key if it happens to be free" do
-    FindFreeKey.should_receive(:exist?).with('free.txt').and_return(false)
+    expect(FindFreeKey).to receive(:exist?).with('free.txt').and_return(false)
 
-    FindFreeKey.find_free_key_like('free.txt').should == 'free.txt'
+    expect(FindFreeKey.find_free_key_like('free.txt')).to eq('free.txt')
   end
 
   it "should append a UUID to the key before the extension if key is taken" do
-    SecureRandom.stub(:uuid).and_return('moo')
-    FindFreeKey.should_receive(:exist?).with('free.txt').and_return(true)
-    FindFreeKey.should_receive(:exist?).with('free_moo.txt').and_return(false)
+    allow(SecureRandom).to receive(:uuid).and_return('moo')
+    expect(FindFreeKey).to receive(:exist?).with('free.txt').and_return(true)
+    expect(FindFreeKey).to receive(:exist?).with('free_moo.txt').and_return(false)
 
-    FindFreeKey.find_free_key_like('free.txt').should == 'free_moo.txt'
+    expect(FindFreeKey.find_free_key_like('free.txt')).to eq('free_moo.txt')
   end
 
 
   it "should not strip any directory information from the key" do
-    SecureRandom.stub(:uuid).and_return('moo')
-    FindFreeKey.should_receive(:exist?).with('products/images/image.gif').and_return(true)
-    FindFreeKey.should_receive(:exist?).with('products/images/image_moo.gif').and_return(false)
+    allow(SecureRandom).to receive(:uuid).and_return('moo')
+    expect(FindFreeKey).to receive(:exist?).with('products/images/image.gif').and_return(true)
+    expect(FindFreeKey).to receive(:exist?).with('products/images/image_moo.gif').and_return(false)
 
-    FindFreeKey.find_free_key_like('products/images/image.gif').should == 'products/images/image_moo.gif'
+    expect(FindFreeKey.find_free_key_like('products/images/image.gif')).to eq('products/images/image_moo.gif')
   end
 
   it "should raise an exception if the randomly chosen value (after 10 attempts) is also taken" do
-    FindFreeKey.stub(:exist?).and_return(true)
-    lambda { FindFreeKey.find_free_key_like('free.txt') }.should raise_error(StandardError)
+    allow(FindFreeKey).to receive(:exist?).and_return(true)
+    expect { FindFreeKey.find_free_key_like('free.txt') }.to raise_error(StandardError)
   end
 
   it "should append a UUID to the key before the extensions if the force_uuid option is passed" do
-    FindFreeKey.should_receive(:exist?).with('free.txt').and_return(false)
-    FindFreeKey.should_receive(:exist?).with('free_as-in-beer.txt').and_return(false)
-    SecureRandom.stub(:uuid).and_return('as-in-beer')
+    expect(FindFreeKey).to receive(:exist?).with('free.txt').and_return(false)
+    expect(FindFreeKey).to receive(:exist?).with('free_as-in-beer.txt').and_return(false)
+    allow(SecureRandom).to receive(:uuid).and_return('as-in-beer')
 
-    FindFreeKey.find_free_key_like('free.txt', :force_uuid => true).should == 'free_as-in-beer.txt'
+    expect(FindFreeKey.find_free_key_like('free.txt', :force_uuid => true)).to eq('free_as-in-beer.txt')
   end
 end

--- a/spec/gcs_bucket_remote_spec.rb
+++ b/spec/gcs_bucket_remote_spec.rb
@@ -104,7 +104,7 @@ describe AssetCloud::GCSBucket, if: ENV['GCS_PROJECT_ID'] && ENV['GCS_KEY_FILEPA
     @bucket.write(key, StringIO.new(value))
 
     data = @bucket.read(key)
-    data.should == value
+    expect(data).to eq(value)
   end
 
   it "#read raises AssetCloud::AssetNotFoundError if the file is not found" do

--- a/spec/gcs_bucket_spec.rb
+++ b/spec/gcs_bucket_spec.rb
@@ -107,7 +107,7 @@ describe AssetCloud::GCSBucket do
     expect_any_instance_of(Google::Cloud::Storage::File).to receive(:download).and_return(StringIO.new(value))
 
     data = @bucket.read(key)
-    data.should == value
+    expect(data).to eq(value)
   end
 
   it "#read raises AssetCloud::AssetNotFoundError if the file is not found" do

--- a/spec/memory_bucket_spec.rb
+++ b/spec/memory_bucket_spec.rb
@@ -14,19 +14,19 @@ describe AssetCloud::MemoryBucket do
   describe 'modifying items in subfolder' do
 
     it "should return nil when file does not exist" do
-      @fs['memory/essay.txt'].exist?.should == false
+      expect(@fs['memory/essay.txt'].exist?).to eq(false)
     end
 
     it "should return set content when asked for the same file" do
       @fs['memory/essay.txt'] = 'text'
-      @fs['memory/essay.txt'].value.should == 'text'
+      expect(@fs['memory/essay.txt'].value).to eq('text')
     end
 
   end
 
   describe "#versioned?" do
     it "should return false" do
-      @fs.buckets[:memory].versioned?.should == false
+      expect(@fs.buckets[:memory].versioned?).to eq(false)
     end
   end
 
@@ -38,11 +38,11 @@ describe AssetCloud::MemoryBucket do
     end
 
     it "should return a list of assets which start with the given prefix" do
-      @fs.buckets[:memory].ls('memory/a').size.should == 2
+      expect(@fs.buckets[:memory].ls('memory/a').size).to eq(2)
     end
 
     it "should return a list of all assets when a prefix is not given" do
-      @fs.buckets[:memory].ls.size.should == 4
+      expect(@fs.buckets[:memory].ls.size).to eq(4)
     end
   end
 end

--- a/spec/remote_s3_bucket_spec.rb
+++ b/spec/remote_s3_bucket_spec.rb
@@ -58,7 +58,7 @@ describe 'Remote test for AssetCloud::S3Bucket', if: ENV['AWS_ACCESS_KEY_ID'] &&
   it "#delete should always return true" do
     @cloud['tmp/test1.txt'] = 'test1'
 
-    @bucket.delete('tmp/test1.txt').should == true
+    expect(@bucket.delete('tmp/test1.txt')).to eq(true)
   end
 
   it "#stat should get metadata from S3" do
@@ -66,8 +66,8 @@ describe 'Remote test for AssetCloud::S3Bucket', if: ENV['AWS_ACCESS_KEY_ID'] &&
     value = 'hello world'
     @cloud.build('tmp/new_file.test', value).store
     metadata = @bucket.stat('tmp/new_file.test')
-    metadata.size.should == value.size
-    metadata.updated_at.should >= start_time
+    expect(metadata.size).to eq(value.size)
+    expect(metadata.updated_at).to be >= start_time
   end
 
   it "#stat a missing asset" do
@@ -81,7 +81,7 @@ describe 'Remote test for AssetCloud::S3Bucket', if: ENV['AWS_ACCESS_KEY_ID'] &&
     key = 'tmp/new_file.txt'
     @bucket.write(key, value)
     data = @bucket.read(key)
-    data.should == value
+    expect(data).to eq(value)
   end
 
   it "#read a missing asset" do
@@ -94,6 +94,6 @@ describe 'Remote test for AssetCloud::S3Bucket', if: ENV['AWS_ACCESS_KEY_ID'] &&
     options = {range: 0...5}
     @bucket.write(key, value)
     data = @bucket.read(key, options)
-    data.should == 'hello'
+    expect(data).to eq('hello')
   end
 end

--- a/spec/s3_bucket_spec.rb
+++ b/spec/s3_bucket_spec.rb
@@ -47,15 +47,15 @@ describe AssetCloud::S3Bucket do
   it "#delete should always return true" do
     expect_any_instance_of(MockS3Interface::NullS3Object).to receive(:delete).and_return(nil)
 
-    @bucket.delete('assets/fail.gif').should == true
+    expect(@bucket.delete('assets/fail.gif')).to eq(true)
   end
 
   it "#stat should get metadata from S3" do
     value = 'hello world'
     @cloud.build('tmp/new_file.test', value).store
     metadata = @bucket.stat('tmp/new_file.test')
-    metadata.size.should == value.size
-    metadata.updated_at.should == Time.parse("Mon Aug 27 17:37:51 UTC 2007")
+    expect(metadata.size).to eq(value.size)
+    expect(metadata.updated_at).to eq(Time.parse("Mon Aug 27 17:37:51 UTC 2007"))
   end
 
   it "#read " do
@@ -63,6 +63,6 @@ describe AssetCloud::S3Bucket do
     key = 'tmp/new_file.txt'
     @bucket.write(key, value)
     data = @bucket.read(key)
-    data.should == value
+    expect(data).to eq(value)
   end
 end

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -23,19 +23,19 @@ describe ValidatedAsset do
 
   describe "#store" do
     it "should not store the asset unless validations pass" do
-      @cloud.should_receive(:write).with('dog_pound/fido', 'dog').and_return(true)
+      expect(@cloud).to receive(:write).with('dog_pound/fido', 'dog').and_return(true)
 
       @cat.store
-      @cat.store.should == false
-      @cat.errors.should == ['no cats allowed!']
-      @dog.store.should == true
+      expect(@cat.store).to eq(false)
+      expect(@cat.errors).to eq(['no cats allowed!'])
+      expect(@dog.store).to eq(true)
     end
 
     it "should store asset with warnings and save them in the warnings array" do
-      @dog.store.should == true
-      @dog.warnings.should == ['bad dog!', 'wet dog smell!']
-      @cat.store.should == false
-      @cat.warnings.should == []
+      expect(@dog.store).to eq(true)
+      expect(@dog.warnings).to eq(['bad dog!', 'wet dog smell!'])
+      expect(@cat.store).to eq(false)
+      expect(@cat.warnings).to eq([])
     end
   end
 
@@ -45,19 +45,19 @@ describe ValidatedAsset do
     end
 
     it "should return true when validations pass" do
-      @dog.store!.should == true
+      expect(@dog.store!).to eq(true)
     end
   end
 
   describe "#valid?" do
     it "should clear errors, run validations, and return validity" do
       @cat.store
-      @cat.errors.should == ['no cats allowed!']
-      @cat.valid?.should == false
-      @cat.errors.should == ['no cats allowed!']
+      expect(@cat.errors).to eq(['no cats allowed!'])
+      expect(@cat.valid?).to eq(false)
+      expect(@cat.errors).to eq(['no cats allowed!'])
       @cat.value = 'disguised feline'
-      @cat.valid?.should == true
-      @cat.errors.should be_empty
+      expect(@cat.valid?).to eq(true)
+      expect(@cat.errors).to be_empty
     end
   end
 end

--- a/spec/versioned_memory_bucket_spec.rb
+++ b/spec/versioned_memory_bucket_spec.rb
@@ -16,20 +16,20 @@ describe AssetCloud::VersionedMemoryBucket do
 
   describe '#versioned?' do
     it "should return true" do
-      @fs.buckets[:memory].versioned?.should == true
+      expect(@fs.buckets[:memory].versioned?).to eq(true)
     end
   end
 
   describe '#read_version' do
     it "should return the appropriate data when given a key and version" do
-      @fs.read_version('memory/foo', 1).should == 'one'
-      @fs.read_version('memory/foo', 3).should == 'three'
+      expect(@fs.read_version('memory/foo', 1)).to eq('one')
+      expect(@fs.read_version('memory/foo', 3)).to eq('three')
     end
   end
 
   describe '#versions' do
     it "should return a list of available version identifiers for the given key" do
-      @fs.versions('memory/foo').should == [1,2,3]
+      expect(@fs.versions('memory/foo')).to eq([1,2,3])
     end
   end
 


### PR DESCRIPTION
This prevents a number of deprecation warnings, such as:

> Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/andyw8/src/github.com/Shopify/asset_cloud/spec/bucket_chain_spec.rb:34:in `block (4 levels) in <top (required)>'.

> Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/andyw8/src/github.com/Shopify/asset_cloud/spec/bucket_chain_spec.rb:27:in `block (3 levels) in <top (required)>'.

The conversion was performed automatically with [transpec](https://github.com/yujinakayama/transpec).