### PR TITLE
Fix a Ruby 2.7 warning in GCS bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,9 @@ before_install:
 rvm:
   - '2.5'
   - '2.6'
+  - '2.7'
+
+matrix:
+  exclude:
+    rvm: '2.7'
+    gemfile: gemfiles/Gemfile.activerecord52

--- a/lib/asset_cloud/buckets/gcs_bucket.rb
+++ b/lib/asset_cloud/buckets/gcs_bucket.rb
@@ -17,7 +17,7 @@ module AssetCloud
       bucket.create_file(
         data,
         absolute_key(key),
-        options
+        **options,
       )
     end
 

--- a/spec/gcs_bucket_spec.rb
+++ b/spec/gcs_bucket_spec.rb
@@ -38,16 +38,29 @@ describe AssetCloud::GCSBucket do
     expect(file.class).to(eq(Google::Cloud::Storage::File))
   end
 
-  it "#write writes a file into the bucket" do
-    local_path = "#{directory}/products/key.txt"
-    key = 'test/key.txt'
-    expect_any_instance_of(MockGCSBucket).to(receive(:create_file).with(
-      local_path,
-      "s#{@cloud.url}/#{key}",
-      {}
-    ))
+  if RUBY_VERSION >= '2.7'
+    it "#write writes a file into the bucket" do
+      local_path = "#{directory}/products/key.txt"
+      key = 'test/key.txt'
+      expect_any_instance_of(MockGCSBucket).to(receive(:create_file).with(
+        local_path,
+        "s#{@cloud.url}/#{key}",
+      ))
 
-    @bucket.write(key, local_path)
+      @bucket.write(key, local_path)
+    end
+  else
+    it "#write writes a file into the bucket" do
+      local_path = "#{directory}/products/key.txt"
+      key = 'test/key.txt'
+      expect_any_instance_of(MockGCSBucket).to(receive(:create_file).with(
+        local_path,
+        "s#{@cloud.url}/#{key}",
+        {}
+      ))
+
+      @bucket.write(key, local_path)
+    end
   end
 
   it "#write writes a file into the bucket with metadata" do


### PR DESCRIPTION
That's the only one I could spot.
```
/tmp/bundle/ruby/2.7.0/gems/asset_cloud-2.5.3/lib/asset_cloud/buckets/gcs_bucket.rb:17: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/bundle/ruby/2.7.0/gems/google-cloud-storage-1.21.1/lib/google/cloud/storage/bucket.rb:1247: warning: The called method `create_file' is defined here
```
