### PR TITLE
Add #write! method which validates before writing content.

### DIFF
--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -151,6 +151,12 @@ module AssetCloud
       bucket_for(key).write(key, value)
     end
 
+    def write!(key, value)
+      asset = self[key]
+      asset.value = value
+      asset.store!
+    end
+
     def read(key)
       logger.info { "  [#{self.class.name}] Reading from #{key}" } if logger
 


### PR DESCRIPTION
It is very common to see AssetCloud being used like this

    asset = cloud['my_file.txt']
    asset.value = "something"
    asset.store!

This is because neither `write` nor `[]=` raise in the case of
failure, making them often unsuitable. Adding a method that does
the same thing as `[]=` but raises on failure to store is therefore
helpful.