### PR TITLE
Fix for callbacks defined in an external class

### DIFF
--- a/lib/asset_cloud/callbacks.rb
+++ b/lib/asset_cloud/callbacks.rb
@@ -59,15 +59,15 @@ module AssetCloud
 
     def execute_callbacks(symbol, args)
       callbacks_for(symbol).each do |callback|
-
+        
         result = case callback
         when Symbol
           send(callback, *args)
         when Proc, Method
           callback.call(self, *args)
         else
-          if callback.respond_to?(method)
-            callback.send(method, self, *args)
+          if callback.respond_to?(symbol)
+            callback.send(symbol, self, *args)
           else
             raise StandardError, "Callbacks must be a symbol denoting the method to call, a string to be evaluated, a block to be invoked, or an object responding to the callback method."
           end


### PR DESCRIPTION
Resolves https://github.com/Shopify/asset_cloud/issues/71

Callbacks do not work when they are defined in a separate class. This PR addresses the bug that is causing the error. Please see the linked issue for additional detail.

The underlying problem is that `method` is being referenced in a code path rather than `symbol`. `method` is part of ruby and requires an argument to be invoked, hence the `wrong number of arguments (given 0, expected 1)` error that is raised when using this pattern on callbacks.