### PR TITLE
Adds rename functionality to GCS assets

### DIFF
--- a/lib/asset_cloud/asset.rb
+++ b/lib/asset_cloud/asset.rb
@@ -103,6 +103,10 @@ module AssetCloud
       end
     end
 
+    def rename(new_key)
+      cloud.rename(key, new_key)
+    end
+
     def metadata
       @metadata ||= cloud.stat(key)
     end

--- a/lib/asset_cloud/bucket.rb
+++ b/lib/asset_cloud/bucket.rb
@@ -24,6 +24,10 @@ module AssetCloud
       raise NotImplementedError
     end
 
+    def rename(key, new_key)
+      raise NotImplementedError
+    end
+
     def write(key, data)
       raise NotImplementedError
     end

--- a/lib/asset_cloud/buckets/gcs_bucket.rb
+++ b/lib/asset_cloud/buckets/gcs_bucket.rb
@@ -13,6 +13,17 @@ module AssetCloud
       downloaded.read
     end
 
+    def rename(key, new_key)
+      file = find_by_key!(key)
+
+      return if new_key.blank?
+
+      renamed_file = file.copy(new_key)
+      file.delete
+
+      renamed_file
+    end
+
     def write(key, data, options = {})
       bucket.create_file(
         data,

--- a/spec/gcs_bucket_spec.rb
+++ b/spec/gcs_bucket_spec.rb
@@ -117,6 +117,29 @@ describe AssetCloud::GCSBucket do
     end.not_to(raise_error)
   end
 
+  it "#rename creates a copy with a new name and deletes the original file from the bucket" do
+    key = "test/key.txt"
+    new_key = "test/new_key.txt"
+    expect_any_instance_of(MockGCSBucket).to(receive(:file).with("s#{@cloud.url}/#{key}")
+      .and_return(Google::Cloud::Storage::File.new))
+    expect_any_instance_of(Google::Cloud::Storage::File)
+      .to(receive(:copy).with(new_key)).and_return(Google::Cloud::Storage::File.new)
+    expect_any_instance_of(Google::Cloud::Storage::File).to(receive(:delete).with(no_args))
+
+    expect do
+      @bucket.rename(key, new_key)
+    end.not_to(raise_error)
+  end
+
+  it "#rename returns if new_key is empty" do
+    key = "test/key.txt"
+    new_key = ""
+    expect_any_instance_of(MockGCSBucket).to(receive(:file).with("s#{@cloud.url}/#{key}")
+      .and_return(Google::Cloud::Storage::File.new))
+
+    expect(@bucket.rename(key, new_key)).to(be_nil)
+  end
+
   it "#read returns the data of the file" do
     value = "hello world"
     key = "tmp/new_file.txt"


### PR DESCRIPTION
This PR adds object rename functionality to Asset Cloud - GCS (google storage)
Part of [GSD 33722](https://vault.shopify.io/gsd/projects/33722)
Context: [Issue #410021 ]https://github.com/Shopify/shopify/issues/410021

What we are trying to accomplish: 
Add the ability to rename objects on Asset Cloud - GCS as a first step to implement this functionality in Core to support File renaming