### PR TITLE
Check for `force_uuid` flag before calling `exist?(key)`

### DIFF
--- a/lib/asset_cloud/free_key_locator.rb
+++ b/lib/asset_cloud/free_key_locator.rb
@@ -8,7 +8,7 @@ module AssetCloud
       # Check weather the suggested key name is free. If so we
       # simply return it.
 
-      if !exist?(key) && !options[:force_uuid]
+      if !options[:force_uuid] && !exist?(key)
         key
       else
         ext         = File.extname(key)

--- a/spec/find_free_key_spec.rb
+++ b/spec/find_free_key_spec.rb
@@ -35,7 +35,6 @@ describe "FreeFilenameLocator", "when asked to return a free key such as the one
   end
 
   it "should append a UUID to the key before the extensions if the force_uuid option is passed" do
-    expect(FindFreeKey).to(receive(:exist?).with("free.txt").and_return(false))
     expect(FindFreeKey).to(receive(:exist?).with("free_as-in-beer.txt").and_return(false))
     allow(SecureRandom).to(receive(:uuid).and_return("as-in-beer"))
 


### PR DESCRIPTION
`exist?` uses `metadata` to find a corresponding asset https://github.com/Shopify/asset_cloud/blob/c85c4066cc11983da62311a110701a2f2f7e5c1a/lib/asset_cloud/asset.rb#L78-L80

In core, this translates to querying the `StoredAsset` table. However, if the `options[:force_uuid]` is set, we don't need to even check for an existing asset with the same key. 

This PR simply swaps the order of checks so we return the `else` early if `force_uuid` is set