### PR TITLE
Fix an issue that was preventing the usage of `Procs` with callback methods

### DIFF
--- a/lib/asset_cloud/callbacks.rb
+++ b/lib/asset_cloud/callbacks.rb
@@ -35,13 +35,13 @@ module AssetCloud
         end
 
         define_singleton_method(before) do |*callbacks, &block|
-          callbacks << block if block_given?
+          callbacks << block unless block.nil?
           callbacks = (_callbacks[before] || []) + callbacks
           self._callbacks = _callbacks.merge(before => callbacks).freeze
         end
 
         define_singleton_method(after) do |*callbacks, &block|
-          callbacks << block if block_given?
+          callbacks << block unless block.nil?
           callbacks = (_callbacks[after] || []) + callbacks
           self._callbacks = _callbacks.merge(after => callbacks).freeze
         end

--- a/spec/callbacks_spec.rb
+++ b/spec/callbacks_spec.rb
@@ -16,7 +16,13 @@ class CallbackAsset < AssetCloud::Asset
   after_validate :add_spice
   validate :valid_value
 
+  before_validate(&:proc_executed_before)
+  after_validate(&:proc_executed_after)
+
   after_store ::AfterStoreCallback
+
+  def proc_executed_before(*args); end
+  def proc_executed_after(*args); end
 
   private
 
@@ -137,6 +143,24 @@ describe CallbackAsset do
     @asset.value = "foo"
     expect(@asset.store).to(eq(true))
     expect(@asset.value).to(eq("valid spice"))
+  end
+
+  it "should run before_validate with procs" do
+    expect(@asset).to(receive(:callback_before_store).and_return(true))
+    expect(@asset).to(receive(:proc_executed_before))
+
+    @asset.value = "foo"
+
+    expect(@asset.store).to(eq(true))
+  end
+
+  it "should run after_validate with procs" do
+    expect(@asset).to(receive(:callback_before_store).and_return(true))
+    expect(@asset).to(receive(:proc_executed_after))
+
+    @asset.value = "foo"
+
+    expect(@asset.store).to(eq(true))
   end
 
   it "should run its after_delete callback after delete is called" do


### PR DESCRIPTION
### Why are these changes introduced?

This PR fixes an issue that was preventing the usage of `Procs` with callback methods.

### What is this pull request doing?

When we're resolving the callback logic we were relying `callbacks << block if block_given?` instead of `block unless block.nil?`.

The `block_given?` keyword checks if a block has been passed to the current _method_, but it doesn't work in the context of callbacks. Here's a more expressive example of what's happening:

```ruby
obj = Object.new

obj.define_singleton_method(:hello1) do |*callbacks, &block|
  puts "Hello, I am a singleton method!"
  block.call if block
end

obj.define_singleton_method(:hello2) do |*callbacks, &block|
  puts "Hello, I am a singleton method!"
  block.call if block_given?
end

obj.hello1 { puts "..and I'm a block!" }
# Hello, I am a singleton method!
# ..and I'm a block!

obj.hello2 { puts "..and I'm a block!" }
# Hello, I am a singleton method!
```