### PR TITLE
Remove callbacks for methods that don't exist

### DIFF
--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -32,7 +32,7 @@ require "asset_cloud/asset_extension"
 AssetCloud::Base.class_eval do
   include AssetCloud::FreeKeyLocator
   include AssetCloud::Callbacks
-  callback_methods :create, :update, :write, :delete
+  callback_methods :write, :delete
 end
 
 AssetCloud::Asset.class_eval do


### PR DESCRIPTION
These were added in https://github.com/Shopify/asset_cloud/pull/51, but never ended up being used.