### PR TITLE
Refactor execute_callbacks to allow subclassing & instrumentation

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Asset Cloud Version History
 
+## Unreleased
+
+* Refactor AssetCloud::Callbacks.execute_callbacks to allow for subclassing
+
 ## Version 2.7.2, 2023-04-20
 
 * Swap the order of operations for checking UUID and asset exist logic in free key locator (https://github.com/Shopify/asset_cloud/pull/83)

--- a/lib/asset_cloud/callbacks.rb
+++ b/lib/asset_cloud/callbacks.rb
@@ -61,24 +61,28 @@ module AssetCloud
 
     def execute_callbacks(symbol, args)
       callbacks_for(symbol).each do |callback|
-        result = case callback
-        when Symbol
-          send(callback, *args)
-        when Proc, Method
-          callback.call(self, *args)
-        else
-          if callback.respond_to?(symbol)
-            callback.send(symbol, self, *args)
-          else
-            raise StandardError,
-              "Callbacks must be a symbol denoting the method to call, " \
-                "a string to be evaluated, a block to be invoked, " \
-                "or an object responding to the callback method."
-          end
-        end
+        result = execute_callback(symbol, callback, args)
         return false if result == false
       end
       true
+    end
+
+    def execute_callback(symbol, callback, args)
+      case callback
+      when Symbol
+        send(callback, *args)
+      when Proc, Method
+        callback.call(self, *args)
+      else
+        if callback.respond_to?(symbol)
+          callback.send(symbol, self, *args)
+        else
+          raise StandardError,
+            "Callbacks must be a symbol denoting the method to call, " \
+              "a string to be evaluated, a block to be invoked, " \
+              "or an object responding to the callback method."
+        end
+      end
     end
 
     def callbacks_for(symbol)


### PR DESCRIPTION
My main goal is to make it easier to instrument callbacks happening in my application.

```ruby

class MyAsset < AssetCloud::Asset
  ...

  def execute_callback(symbol, callback, args)
    ActiveSupport::Notifications.instrument "callbacks.my_asset", callbacks_name: symbol, callback: callback do
      super
    end
  end
end
```