### PR TITLE
Validate keys in `ls`, `read_version`, `versions`, and `version_details`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    asset_cloud (2.7.4)
+    asset_cloud (2.7.5)
       activesupport
 
 GEM

--- a/asset_cloud.gemspec
+++ b/asset_cloud.gemspec
@@ -4,7 +4,7 @@
 require "English"
 Gem::Specification.new do |s|
   s.name = "asset_cloud"
-  s.version = "2.7.4"
+  s.version = "2.7.5"
 
   s.authors = ["Shopify"]
   s.summary = "An abstraction layer around arbitrary and diverse asset stores."

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -186,6 +186,7 @@ module AssetCloud
     end
 
     def ls(key)
+      check_key_for_errors(key)
       logger&.info { "  [#{self.class.name}] Listing objects in #{key}" }
 
       bucket_for(key).ls(key)
@@ -228,16 +229,19 @@ module AssetCloud
     # versioning
 
     def read_version(key, version)
+      check_key_for_errors(key)
       logger&.info { "  [#{self.class.name}] Reading from #{key} at version #{version}" }
       bucket_for(key).read_version(key, version)
     end
 
     def versions(key)
+      check_key_for_errors(key)
       logger&.info { "  [#{self.class.name}] Getting all versions for #{key}" }
       bucket_for(key).versions(key)
     end
 
     def version_details(key)
+      check_key_for_errors(key)
       logger&.info { "  [#{self.class.name}] Getting all version details for #{key}" }
       bucket_for(key).version_details(key)
     end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -230,6 +230,22 @@ describe BasicCloud do
     it "should raise IllegalPath on write with traversal key" do
       expect { @fs.write("../secret.txt", "data") }.to(raise_error(AssetCloud::IllegalPath))
     end
+
+    it "should raise IllegalPath on ls with traversal key" do
+      expect { @fs.ls("../secret") }.to(raise_error(AssetCloud::IllegalPath))
+    end
+
+    it "should raise IllegalPath on read_version with traversal key" do
+      expect { @fs.read_version("../secret.txt", 1) }.to(raise_error(AssetCloud::IllegalPath))
+    end
+
+    it "should raise IllegalPath on versions with traversal key" do
+      expect { @fs.versions("../secret.txt") }.to(raise_error(AssetCloud::IllegalPath))
+    end
+
+    it "should raise IllegalPath on version_details with traversal key" do
+      expect { @fs.version_details("../secret.txt") }.to(raise_error(AssetCloud::IllegalPath))
+    end
   end
 
   describe "MATCH_BUCKET" do


### PR DESCRIPTION
This is a follow-up to #135 which added key validation to `read`, `stat` and `delete`.

This PR adds the same validation to the remaining methods that accept `key`.