### PR TITLE
Autoload buckets and base

### DIFF
--- a/lib/asset_cloud.rb
+++ b/lib/asset_cloud.rb
@@ -14,26 +14,29 @@ require "asset_cloud/buckets/file_system_bucket"
 require "asset_cloud/buckets/invalid_bucket"
 require "asset_cloud/buckets/memory_bucket"
 require "asset_cloud/buckets/versioned_memory_bucket"
-require "asset_cloud/base"
 
-# S3
-require "asset_cloud/buckets/s3_bucket"
+# Core entry-point class and external-SDK backends are autoloaded so that
+# requiring asset_cloud does not load asset_cloud/base or pull in aws-sdk-s3
+# (or the GCS SDK) at boot. They are eager-loaded in production by the Railtie.
+module AssetCloud
+  autoload :Base, "asset_cloud/base"
+  autoload :S3Bucket, "asset_cloud/buckets/s3_bucket"
+  autoload :GCSBucket, "asset_cloud/buckets/gcs_bucket"
 
-# GCS
-require "asset_cloud/buckets/gcs_bucket"
+  class << self
+    def eager_load!
+      _ = Base
+      _ = S3Bucket
+      _ = GCSBucket
+    end
+  end
+end
 
 # Extensions
-require "asset_cloud/free_key_locator"
 require "asset_cloud/callbacks"
 require "asset_cloud/validations"
 
 require "asset_cloud/asset_extension"
-
-AssetCloud::Base.class_eval do
-  include AssetCloud::FreeKeyLocator
-  include AssetCloud::Callbacks
-  callback_methods :write, :delete
-end
 
 AssetCloud::Asset.class_eval do
   include AssetCloud::Callbacks
@@ -63,4 +66,8 @@ AssetCloud::Asset.class_eval do
       add_error("#{key.inspect} contains illegal characters")
     end
   end
+end
+
+if defined?(Rails::Railtie)
+  require "asset_cloud/railtie"
 end

--- a/lib/asset_cloud/base.rb
+++ b/lib/asset_cloud/base.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "uri/rfc2396_parser"
+require "asset_cloud/free_key_locator"
+require "asset_cloud/callbacks"
 
 module AssetCloud
   class IllegalPath < StandardError
@@ -286,5 +288,9 @@ module AssetCloud
       logger&.info { "  [#{self.class.name}]   bad key #{e.message}" }
       raise
     end
+
+    include AssetCloud::FreeKeyLocator
+    include AssetCloud::Callbacks
+    callback_methods :write, :delete
   end
 end

--- a/lib/asset_cloud/buckets/gcs_bucket.rb
+++ b/lib/asset_cloud/buckets/gcs_bucket.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+gem "google-cloud-storage"
+require "google-cloud-storage"
+
 module AssetCloud
   class GCSBucket < Bucket
     def ls(key = nil)

--- a/lib/asset_cloud/buckets/s3_bucket.rb
+++ b/lib/asset_cloud/buckets/s3_bucket.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+gem "aws-sdk-s3"
 require "aws-sdk-s3"
 
 module AssetCloud

--- a/lib/asset_cloud/railtie.rb
+++ b/lib/asset_cloud/railtie.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails/railtie"
+require "asset_cloud"
+
+module AssetCloud
+  class Railtie < Rails::Railtie
+    config.eager_load_namespaces << AssetCloud
+  end
+end


### PR DESCRIPTION
Redo https://github.com/Shopify/asset_cloud/pull/78

Buckets should be autoloaded because they require asset libraries that may not be used by the host application. As asset cloud grows in size, it is also a good approach to adopt as to not require too many files at boot time when, in many cases, asset cloud will not be used.